### PR TITLE
download: allow to pass the desired filename of the zip file (fixes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ itself.
 ### Parameters
 * `dest_path` (`str`, optional, default: `.`): destination folder for the
   dataset
-* `unzip` (`bool`, optional, default: `True`): indication of whether the
+* `dest_filename` (`str`, optional, default: `numerai_dataset_<date>.zip`)
+* `unzip (`bool`, optional, default: `True`): indication of whether the
   training data should be unzipped
 ### Return Values
 * `path` (`string`): location of the downloaded dataset

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -85,7 +85,7 @@ class NumerAPI(object):
             # ensure it ends with ".zip"
             if not dest_filename.endswith(".zip"):
                 dest_filename += ".zip"
-        dataset_path = "{0}/{1}".format(dest_path, dest_filename)
+        dataset_path = os.path.join(dest_path, dest_filename)
 
         if os.path.exists(dataset_path):
             self.logger.info("target file already exists")

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -67,19 +67,25 @@ class NumerAPI(object):
 
         return True
 
-    def download_current_dataset(self, dest_path=".", unzip=True):
+    def download_current_dataset(self, dest_path=".", dest_filename=None,
+                                 unzip=True):
         """download dataset for current round
 
-        dest_path: desired location of dataset file
+        dest_path: desired location of dataset file (optional)
+        dest_filename: desired filename of dataset file (optional)
         unzip: indicates whether to unzip dataset
         """
         self.logger.info("downloading current dataset...")
 
         # set up download path
-        now = datetime.datetime.now().strftime("%Y%m%d")
-        dataset_name = "numerai_dataset_{0}".format(now)
-        file_name = "{0}.zip".format(dataset_name)
-        dataset_path = "{0}/{1}".format(dest_path, file_name)
+        if dest_filename is None:
+            now = datetime.datetime.now().strftime("%Y%m%d")
+            dest_filename = "numerai_dataset_{0}.zip".format(now)
+        else:
+            # ensure it ends with ".zip"
+            if not dest_filename.endswith(".zip"):
+                dest_filename += ".zip"
+        dataset_path = "{0}/{1}".format(dest_path, dest_filename)
 
         if os.path.exists(dataset_path):
             self.logger.info("target file already exists")
@@ -106,6 +112,8 @@ class NumerAPI(object):
 
         # unzip dataset
         if unzip:
+            # remove the ".zip" in the end
+            dataset_name = dest_filename[:-4]
             self._unzip_file(dataset_path, dest_path, dataset_name)
 
         return dataset_path


### PR DESCRIPTION
ensures the passed name ends with ".zip" and adds it if missing. This is necessary to keep the `unzip` option working. In contrast to the suggestion in the ticket, directory and filename are passed as two parameters, not as a single path. While this might be nicer, the implemented solution keeps backwards-compatibility. 

I would actually prefer to change the default name to include the round number instead of the current date.. 