### PR TITLE
Feature Request - Expanded Submission Metrics

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -856,23 +856,54 @@ class NumerAPI(base_api.Api):
                  * pending (`bool`)
                  * value (`bool`): whether the submission is concordant
                 * consistency (`float`): consistency of the submission
-                * validationCorrelation (`float`)
                 * filename (`string`)
                 * corrWithExamplePreds (`float`)
-                * validationFeatureExposure (`float`)
+                * validationCorrelation (`float`)
+                * validationCorrelationRating (`float`)
                 * validationSharpe (`float`)
+                * validationSharpeRating  (`float`)
+                * validationFeatureNeutralMean (`float`)
+                * validationFeatureNeutralMeanRating (`float`)
+                * validationStd (`float`)
+                * validationStdRating (`float`)
+                * validationMaxFeatureExposure (`float`)
+                * validationMaxFeatureExposureRating (`float`)
+                * validationMaxDrawdown (`float`)
+                * validationMaxDrawdownRating (`float`)
+                * validationCorrPlusMmcSharpe (`float`)
+                * validationCorrPlusMmcSharpeRating (`float`)
+                * validationMmcMean (`float`)
+                * validationMmcMeanRating (`float`)
+                * validationCorrPlusMmcSharpeDiff (`float`)
+                * validationCorrPlusMmcSharpeDiffRating (`float`)
 
         Example:
             >>> api = NumerAPI(secret_key="..", public_id="..")
             >>> model_id = api.get_models()['uuazed']
             >>> api.submission_status(model_id)
-            {'concordance': None,
-             'consistency': None,
-             'corrWithExamplePreds': 0.3811635610849811,
-             'filename': 'model57-HPzOyr56TPaD.csv',
-             'validationCorrelation': 0.02967954913128146,
-             'validationFeatureExposure': 0.09736206063204657,
-             'validationSharpe': 1.5567641700803665}
+            {'concordance': None, 
+            'consistency': None, 
+            'corrWithExamplePreds': 0.7217288907243551, 
+            'filename': 'model57-HPzOyr56TPaD.csv', 
+            'validationCorrPlusMmcSharpe': 1.0583461013814541, 
+            'validationCorrPlusMmcSharpeDiff': -0.23505145970149166, 
+            'validationCorrPlusMmcSharpeDiffRating': 0.02989708059701668, 
+            'validationCorrPlusMmcSharpeRating': 0.7123167873588739, 
+            'validationCorrelation': 0.023244452475027225, 
+            'validationCorrelationRating': 0.6026148514721896, 
+            'validationFeatureExposure': None, 
+            'validationFeatureNeutralMean': 0.019992061095211483, 
+            'validationFeatureNeutralMeanRating': 0.7689254267389032, 
+            'validationMaxDrawdown': -0.03710774157542396, 
+            'validationMaxDrawdownRating': 0.8099139824952893, 
+            'validationMaxFeatureExposure': 0.17339716040222303, 
+            'validationMaxFeatureExposureRating': 0.9200079988669775, 
+            'validationMmcMean': 0.0027797270044420106, 
+            'validationMmcMeanRating': 0.615821958518417, 
+            'validationSharpe': 1.2933975610829458, 
+            'validationSharpeRating': 0.9921399536701735, 
+            'validationStd': 0.017971622318171787, 
+            'validationStdRating': 0.9842992879669488}           
         """
         query = '''
             query($modelId: String) {
@@ -883,11 +914,29 @@ class NumerAPI(base_api.Api):
                       value
                     }
                     consistency
-                    validationCorrelation
-                    validationFeatureExposure
-                    validationSharpe
+                    filename                    
                     corrWithExamplePreds
-                    filename
+                    validationCorrelation
+                    validationSharpe
+                    validationFeatureExposure
+                    validationCorrelation
+                    validationCorrelationRating
+                    validationSharpe
+                    validationSharpeRating
+                    validationFeatureNeutralMean
+                    validationFeatureNeutralMeanRating
+                    validationStd
+                    validationStdRating
+                    validationMaxFeatureExposure
+                    validationMaxFeatureExposureRating
+                    validationMaxDrawdown
+                    validationMaxDrawdownRating
+                    validationCorrPlusMmcSharpe
+                    validationCorrPlusMmcSharpeRating
+                    validationMmcMean
+                    validationMmcMeanRating
+                    validationCorrPlusMmcSharpeDiff
+                    validationCorrPlusMmcSharpeDiffRating
                   }
                 }
               }


### PR DESCRIPTION
This updates the `submission_status` function in `numerapi.py` to include all the available metrics from the GraphQL query. 

As a consumer I am looking for a way to view these metrics programmatically instead of solely on the numer.ai website.

This is my first PR, open to questions, comments, and feedback.

Thank you for your time