### PR TITLE
Fix stake_change call by adding tournamentNumber parameter

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -1242,7 +1242,7 @@ class NumerAPI(base_api.Api):
         return stake
 
     def stake_change(self, nmr, action: str = "decrease",
-                     model_id: str = None, tournament_number=8) -> Dict:
+                     model_id: str = None, tournament: int = 8) -> Dict:
         """Change stake by `value` NMR.
 
         Args:
@@ -1284,7 +1284,7 @@ class NumerAPI(base_api.Api):
               }
         }
         '''
-        arguments = {'value': str(nmr), 'type': action, 'modelId': model_id, 'tournamentNumber': tournament_number}
+        arguments = {'value': str(nmr), 'type': action, 'modelId': model_id, 'tournamentNumber': tournament}
         result = self.raw_query(query, arguments, authorization=True)
         stake = result['data']['v2ChangeStake']
         utils.replace(stake, "requestedAmount", utils.parse_float_string)

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -1242,7 +1242,7 @@ class NumerAPI(base_api.Api):
         return stake
 
     def stake_change(self, nmr, action: str = "decrease",
-                     model_id: str = None) -> Dict:
+                     model_id: str = None, tournament_number=8) -> Dict:
         """Change stake by `value` NMR.
 
         Args:
@@ -1271,10 +1271,12 @@ class NumerAPI(base_api.Api):
         query = '''
           mutation($value: String!
                    $type: String!
+                   $tournamentNumber: Int!
                    $modelId: String) {
               v2ChangeStake(value: $value
                             type: $type
-                            modelId: $modelId) {
+                            modelId: $modelId
+                            tournamentNumber: $tournamentNumber) {
                 dueDate
                 requestedAmount
                 status
@@ -1282,7 +1284,7 @@ class NumerAPI(base_api.Api):
               }
         }
         '''
-        arguments = {'value': str(nmr), 'type': action, 'modelId': model_id}
+        arguments = {'value': str(nmr), 'type': action, 'modelId': model_id, 'tournamentNumber': tournament_number}
         result = self.raw_query(query, arguments, authorization=True)
         stake = result['data']['v2ChangeStake']
         utils.replace(stake, "requestedAmount", utils.parse_float_string)


### PR DESCRIPTION
The stake_change operation requires a tournament number to be passed through with the request. This change sends through the tournamentNumber, and allows the user to specify a custom tournament number for future compatibility