### PR TITLE
Remove header from signals universe

### DIFF
--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -8,8 +8,11 @@ import requests
 from numerapi import base_api
 from numerapi import utils
 
+SIGNALS_DOM = "https://numerai-signals-public-data.s3-us-west-2.amazonaws.com"
+
 
 class SignalsAPI(base_api.Api):
+    TICKER_UNIVERSE_URL = f"{SIGNALS_DOM}/latest_universe.csv"
 
     def get_leaderboard(self, limit: int = 50, offset: int = 0) -> List[Dict]:
         """Get the current Numerai Signals leaderboard
@@ -351,9 +354,7 @@ class SignalsAPI(base_api.Api):
             >>> SignalsAPI().ticker_universe()
             ["MSFT", "AMZN", "APPL", ...]
         """
-        dom = 'https://numerai-signals-public-data.s3-us-west-2.amazonaws.com'
-        url = f"{dom}/latest_universe.csv"
-        result = requests.get(url, stream=True)
+        result = requests.get(self.TICKER_UNIVERSE_URL, stream=True)
         iterator = codecs.iterdecode(result.iter_lines(), 'utf-8')
         tickers = [t.strip() for t in iterator]
         return tickers

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -356,7 +356,7 @@ class SignalsAPI(base_api.Api):
         """
         result = requests.get(self.TICKER_UNIVERSE_URL, stream=True)
         iterator = codecs.iterdecode(result.iter_lines(), 'utf-8')
-        tickers = [t.strip() for t in iterator]
+        tickers = [t.strip() for t in iterator if t != 'bloomberg_ticker']
         return tickers
 
     def stake_get(self, username) -> decimal.Decimal:

--- a/tests/test_signalsapi.py
+++ b/tests/test_signalsapi.py
@@ -1,8 +1,5 @@
 import pytest
-import os
 import datetime
-import decimal
-import pytz
 import responses
 
 import numerapi
@@ -63,3 +60,12 @@ def test_daily_user_performances(api):
     result = api.daily_user_performances("uuazed")
     assert len(result) == 1
     assert isinstance(result[0]["date"], datetime.datetime)
+
+
+@responses.activate
+def test_ticker_universe(api):
+    data = "bloomberg_ticker\nSTOCK A\nSTOCK B\nSTOCK C"
+    responses.add(responses.GET,
+                  api.TICKER_UNIVERSE_URL, body=data)
+    result = api.ticker_universe()
+    assert len(result) == 4

--- a/tests/test_signalsapi.py
+++ b/tests/test_signalsapi.py
@@ -68,4 +68,5 @@ def test_ticker_universe(api):
     responses.add(responses.GET,
                   api.TICKER_UNIVERSE_URL, body=data)
     result = api.ticker_universe()
-    assert len(result) == 4
+    assert "bloomberg_ticker" not in result
+    assert len(result) == 3


### PR DESCRIPTION
* Added a test for `SignalsAPI.ticker_universe()`
* Remove the header (`'bloomberg_ticker'`) from the list of ticker returned from `SignalsAPI.ticker_universe()`