### PR TITLE
Add get_latest_data_path() and download_latest_data()

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -27,6 +27,8 @@ class NumerAPI(base_api.Api):
     much more.
     """
 
+    PUBLIC_DATASETS_URL = "https://numerai-public-datasets.s3-us-west-2.amazonaws.com"
+
     def _unzip_file(self, src_path, dest_path, filename):
         """unzips file located at src_path into destination_path"""
         self.logger.info("unzipping file...")
@@ -111,6 +113,73 @@ class NumerAPI(base_api.Api):
             self._unzip_file(dataset_path, dest_path, dataset_name)
 
         return dataset_path
+
+    def get_latest_data_path(self, data_type: str, ext: str = "csv") -> str:
+        """Fetch url of the latest data path for a specified data type
+
+        Args:
+            data_type (str): type of data to return
+            data_type (str): file extension to get (optional, defaults to csv)
+
+        Returns:
+            str: url of the requested dataset
+
+        Example:
+            >>> NumerAPI().get_latest_data_path("live", "csv")
+            https://numerai-public-datasets.s3.amazonaws.com/latest_numerai_live_data.csv
+        """
+        valid_exts = ["csv", "csv.xz", "parquet"]
+        valid_data_types = [
+            "live",
+            "training",
+            "validation",
+            "test",
+            "current_test_era",
+            "tournament",
+            "tournament_ids",
+            "example_predictions",
+        ]
+
+        # Allow ext to have a "." as the first character
+        if ext[0] == ".":
+            ext = ext[1:]
+
+        # Validate arguments
+        if ext not in valid_exts:
+            raise ValueError(f"ext must be set to one of {valid_exts}")
+
+        if ext not in valid_exts:
+            raise ValueError(
+                f"data_type must be set to one of {valid_data_types}")
+
+        path = f"{self.PUBLIC_DATASETS_URL}/latest_numerai_{data_type}_data.{ext}"
+
+        return path
+
+    # Convenience functions for get_latest_data_path()
+    def get_latest_live_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("live", ext)
+
+    def get_latest_training_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("training", ext)
+
+    def get_latest_validation_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("validation", ext)
+
+    def get_latest_test_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("test", ext)
+
+    def get_latest_current_test_era_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("current_test_era", ext)
+
+    def get_latest_tournament_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("tournament", ext)
+
+    def get_latest_tournament_ids_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("tournament_ids", ext)
+
+    def get_latest_example_predictions_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("example_predictions", ext)
 
     def get_v1_leaderboard(self, round_num=0, tournament=8):
         """Retrieves the leaderboard for the given round.

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -126,7 +126,7 @@ class NumerAPI(base_api.Api):
 
         Example:
             >>> url = NumerAPI().get_latest_data_url("live", "csv")
-            >>> numerapi.utils.download_file(url)
+            >>> numerapi.utils.download_file(url, ".")
         """
         valid_extensions = ["csv", "csv.xz", "parquet"]
         valid_data_types = [
@@ -155,30 +155,35 @@ class NumerAPI(base_api.Api):
 
         return url
 
-    # Convenience functions for get_latest_data_url()
-    def get_latest_live_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("live", extension)
+    def download_latest_data(self, data_type: str, extension: str, dest_path: str):
+        url = self.get_latest_data_url(data_type, extension)
+        utils.download_file(url, dest_path, self.show_progress_bars)
 
-    def get_latest_training_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("training", extension)
+    # Convenience functions for download_latest_data()
+    # The extension argument must be one of: "csv", "csv.xz", or "parquet"
+    def download_latest_live_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("live", extension, dest_path)
 
-    def get_latest_validation_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("validation", extension)
+    def download_latest_training_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("training", extension, dest_path)
 
-    def get_latest_test_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("test", extension)
+    def download_latest_validation_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("validation", extension, dest_path)
 
-    def get_latest_max_test_era_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("max_test_era", extension)
+    def download_latest_test_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("test", extension, dest_path)
 
-    def get_latest_tournament_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("tournament", extension)
+    def download_latest_max_test_era_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("max_test_era", extension, dest_path)
 
-    def get_latest_tournament_ids_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("tournament_ids", extension)
+    def download_latest_tournament_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("tournament", extension, dest_path)
 
-    def get_latest_example_predictions_data_url(self, extension: str = "csv") -> str:
-        return self.get_latest_data_url("example_predictions", extension)
+    def download_latest_tournament_ids_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("tournament_ids", extension, dest_path)
+
+    def download_latest_example_predictions_data(self, extension="csv", dest_path="."):
+        self.download_latest_data("example_predictions", extension, dest_path)
 
     def get_v1_leaderboard(self, round_num=0, tournament=8):
         """Retrieves the leaderboard for the given round.

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -134,7 +134,7 @@ class NumerAPI(base_api.Api):
             "training",
             "validation",
             "test",
-            "current_test_era",
+            "max_test_era",
             "tournament",
             "tournament_ids",
             "example_predictions",
@@ -169,8 +169,8 @@ class NumerAPI(base_api.Api):
     def get_latest_test_data_path(self, ext: str = "csv") -> str:
         return self.get_latest_data_path("test", ext)
 
-    def get_latest_current_test_era_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("current_test_era", ext)
+    def get_latest_max_test_era_data_path(self, ext: str = "csv") -> str:
+        return self.get_latest_data_path("max_test_era", ext)
 
     def get_latest_tournament_data_path(self, ext: str = "csv") -> str:
         return self.get_latest_data_path("tournament", ext)

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -155,35 +155,9 @@ class NumerAPI(base_api.Api):
 
         return url
 
-    def download_latest_data(self, data_type: str, extension: str, dest_path: str):
+    def download_latest_data(self, data_type: str, extension: str = "csv", dest_path: str = "."):
         url = self.get_latest_data_url(data_type, extension)
         utils.download_file(url, dest_path, self.show_progress_bars)
-
-    # Convenience functions for download_latest_data()
-    # The extension argument must be one of: "csv", "csv.xz", or "parquet"
-    def download_latest_live_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("live", extension, dest_path)
-
-    def download_latest_training_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("training", extension, dest_path)
-
-    def download_latest_validation_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("validation", extension, dest_path)
-
-    def download_latest_test_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("test", extension, dest_path)
-
-    def download_latest_max_test_era_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("max_test_era", extension, dest_path)
-
-    def download_latest_tournament_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("tournament", extension, dest_path)
-
-    def download_latest_tournament_ids_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("tournament_ids", extension, dest_path)
-
-    def download_latest_example_predictions_data(self, extension="csv", dest_path="."):
-        self.download_latest_data("example_predictions", extension, dest_path)
 
     def get_v1_leaderboard(self, round_num=0, tournament=8):
         """Retrieves the leaderboard for the given round.

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -114,21 +114,21 @@ class NumerAPI(base_api.Api):
 
         return dataset_path
 
-    def get_latest_data_path(self, data_type: str, ext: str = "csv") -> str:
-        """Fetch url of the latest data path for a specified data type
+    def get_latest_data_url(self, data_type: str, extension: str = "csv") -> str:
+        """Fetch url of the latest data url for a specified data type
 
         Args:
             data_type (str): type of data to return
-            data_type (str): file extension to get (optional, defaults to csv)
+            extension (str): file extension to get (optional, defaults to csv)
 
         Returns:
             str: url of the requested dataset
 
         Example:
-            >>> NumerAPI().get_latest_data_path("live", "csv")
-            https://numerai-public-datasets.s3.amazonaws.com/latest_numerai_live_data.csv
+            >>> url = NumerAPI().get_latest_data_url("live", "csv")
+            >>> numerapi.utils.download_file(url)
         """
-        valid_exts = ["csv", "csv.xz", "parquet"]
+        valid_extensions = ["csv", "csv.xz", "parquet"]
         valid_data_types = [
             "live",
             "training",
@@ -140,46 +140,45 @@ class NumerAPI(base_api.Api):
             "example_predictions",
         ]
 
-        # Allow ext to have a "." as the first character
-        if ext[0] == ".":
-            ext = ext[1:]
+        # Allow extension to have a "." as the first character
+        extension = extension.lstrip(".")
 
         # Validate arguments
-        if ext not in valid_exts:
-            raise ValueError(f"ext must be set to one of {valid_exts}")
+        if extension not in valid_extensions:
+            raise ValueError(f"extension must be set to one of {valid_extensions}")
 
-        if ext not in valid_exts:
+        if extension not in valid_extensions:
             raise ValueError(
                 f"data_type must be set to one of {valid_data_types}")
 
-        path = f"{self.PUBLIC_DATASETS_URL}/latest_numerai_{data_type}_data.{ext}"
+        url = f"{self.PUBLIC_DATASETS_URL}/latest_numerai_{data_type}_data.{extension}"
 
-        return path
+        return url
 
-    # Convenience functions for get_latest_data_path()
-    def get_latest_live_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("live", ext)
+    # Convenience functions for get_latest_data_url()
+    def get_latest_live_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("live", extension)
 
-    def get_latest_training_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("training", ext)
+    def get_latest_training_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("training", extension)
 
-    def get_latest_validation_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("validation", ext)
+    def get_latest_validation_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("validation", extension)
 
-    def get_latest_test_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("test", ext)
+    def get_latest_test_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("test", extension)
 
-    def get_latest_max_test_era_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("max_test_era", ext)
+    def get_latest_max_test_era_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("max_test_era", extension)
 
-    def get_latest_tournament_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("tournament", ext)
+    def get_latest_tournament_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("tournament", extension)
 
-    def get_latest_tournament_ids_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("tournament_ids", ext)
+    def get_latest_tournament_ids_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("tournament_ids", extension)
 
-    def get_latest_example_predictions_data_path(self, ext: str = "csv") -> str:
-        return self.get_latest_data_path("example_predictions", ext)
+    def get_latest_example_predictions_data_url(self, extension: str = "csv") -> str:
+        return self.get_latest_data_url("example_predictions", extension)
 
     def get_v1_leaderboard(self, round_num=0, tournament=8):
         """Retrieves the leaderboard for the given round.

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -8,8 +8,6 @@ import responses
 import numerapi
 from numerapi import base_api
 
-PUBLIC_DATASETS_URL = "https://numerai-public-datasets.s3-us-west-2.amazonaws.com"
-
 
 @pytest.fixture(scope='function', name="api")
 def api_fixture():
@@ -38,34 +36,34 @@ def test_download_current_dataset(api, tmpdir):
         assert len(rsps.calls) == 0
 
 
-def test_get_latest_data_paths(api):
+def test_get_latest_data_urls(api):
     # Dict of data types and their associated functions
     function_dict = {
-        "live": api.get_latest_live_data_path,
-        "training": api.get_latest_training_data_path,
-        "validation": api.get_latest_validation_data_path,
-        "test": api.get_latest_test_data_path,
-        "max_test_era": api.get_latest_max_test_era_data_path,
-        "tournament": api.get_latest_tournament_data_path,
-        "tournament_ids": api.get_latest_tournament_ids_data_path,
-        "example_predictions": api.get_latest_example_predictions_data_path,
+        "live": api.get_latest_live_data_url,
+        "training": api.get_latest_training_data_url,
+        "validation": api.get_latest_validation_data_url,
+        "test": api.get_latest_test_data_url,
+        "max_test_era": api.get_latest_max_test_era_data_url,
+        "tournament": api.get_latest_tournament_data_url,
+        "tournament_ids": api.get_latest_tournament_ids_data_url,
+        "example_predictions": api.get_latest_example_predictions_data_url,
     }
 
-    exts = ["csv", "csv.xz", "parquet"]
+    extensions = ["csv", "csv.xz", "parquet"]
 
-    # Test each combination of function and ext
+    # Test each combination of function and extension
     for data_type, fn in function_dict.items():
         with pytest.raises(ValueError):
-            path = fn(ext='.txt')
+            url = fn(extension='.txt')
 
-        for ext in exts:
-            expected_path = f"{PUBLIC_DATASETS_URL}/latest_numerai_{data_type}_data.{ext}"
+        for extension in extensions:
+            expected_url = f"{api.PUBLIC_DATASETS_URL}/latest_numerai_{data_type}_data.{extension}"
 
-            path = fn(ext=ext)
-            assert path == expected_path
+            url = fn(extension=extension)
+            assert url == expected_url
 
-            path = fn(ext=f'.{ext}')
-            assert path == expected_path
+            url = fn(extension=f'.{extension}')
+            assert url == expected_url
 
 
 def test_get_current_round(api):

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -45,7 +45,7 @@ def test_get_latest_data_paths(api):
         "training": api.get_latest_training_data_path,
         "validation": api.get_latest_validation_data_path,
         "test": api.get_latest_test_data_path,
-        "current_test_era": api.get_latest_current_test_era_data_path,
+        "max_test_era": api.get_latest_max_test_era_data_path,
         "tournament": api.get_latest_tournament_data_path,
         "tournament_ids": api.get_latest_tournament_ids_data_path,
         "example_predictions": api.get_latest_example_predictions_data_path,

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -36,33 +36,33 @@ def test_download_current_dataset(api, tmpdir):
         assert len(rsps.calls) == 0
 
 
-def test_get_latest_data_urls(api):
-    # Dict of data types and their associated functions
-    function_dict = {
-        "live": api.get_latest_live_data_url,
-        "training": api.get_latest_training_data_url,
-        "validation": api.get_latest_validation_data_url,
-        "test": api.get_latest_test_data_url,
-        "max_test_era": api.get_latest_max_test_era_data_url,
-        "tournament": api.get_latest_tournament_data_url,
-        "tournament_ids": api.get_latest_tournament_ids_data_url,
-        "example_predictions": api.get_latest_example_predictions_data_url,
-    }
+def test_get_latest_data_url(api):
+    # List of data types that have latest data files
+    data_types = [
+        "live",
+        "training",
+        "validation",
+        "test",
+        "max_test_era",
+        "tournament",
+        "tournament_ids",
+        "example_predictions",
+    ]
 
     extensions = ["csv", "csv.xz", "parquet"]
 
     # Test each combination of function and extension
-    for data_type, fn in function_dict.items():
+    for data_type in data_types:
         with pytest.raises(ValueError):
-            url = fn(extension='.txt')
+            url = api.get_latest_data_url(data_type, extension='.txt')
 
         for extension in extensions:
             expected_url = f"{api.PUBLIC_DATASETS_URL}/latest_numerai_{data_type}_data.{extension}"
 
-            url = fn(extension=extension)
+            url = api.get_latest_data_url(data_type, extension)
             assert url == expected_url
 
-            url = fn(extension=f'.{extension}')
+            url = api.get_latest_data_url(data_type, f'.{extension}')
             assert url == expected_url
 
 


### PR DESCRIPTION
In the S3 public bucket, we're adding new lightweight data files for:
- Test
- Live
- Validation
- Latest test era
- Tournament IDs

These are present for the most recent week, and are marked as "latest". E.g. `latest_numerai_live_data.csv`

This is so users don't have to download the entire dataset every time. ETA for these changes to go live is Monday.