### PR TITLE
Resumable Download

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -103,10 +103,6 @@ class NumerAPI(base_api.Api):
                 dest_filename += ".zip"
         dataset_path = os.path.join(dest_path, dest_filename)
 
-        if os.path.exists(dataset_path):
-            self.logger.info("target file already exists")
-            # return dataset_path
-
         # create parent folder if necessary
         utils.ensure_directory_exists(dest_path)
 

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -105,7 +105,7 @@ class NumerAPI(base_api.Api):
 
         if os.path.exists(dataset_path):
             self.logger.info("target file already exists")
-            return dataset_path
+            # return dataset_path
 
         # create parent folder if necessary
         utils.ensure_directory_exists(dest_path)


### PR DESCRIPTION
I noticed that that when `napi.download_current_dataset()` is called and if for whatever reason the download is interrupted, calling the function again simply returns with `INFO numerapi.base_api: target file already exists`. Made a quick fix for this by updating the `utils.py` and skipping the "file already exists" check in `numerapi.py`.