### PR TITLE
Support pandas 1.1.0, 1.1.5, 1.2.4  with new implementation of DataFrame uploads and lower requirements and test requirements to pandas 1.1.0 and above

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -744,10 +744,8 @@ class NumerAPI(base_api.Api):
         buffer_csv = None
 
         if df is not None:
-            buffer_csv = BytesIO()
+            buffer_csv = BytesIO(df.to_csv(index = False).encode()) 
             buffer_csv.name = file_path
-            df.to_csv(buffer_csv, index=False)
-            buffer_csv.seek(0)
 
         auth_query = '''
             query($filename: String!

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -743,10 +743,8 @@ class NumerAPI(base_api.Api):
         buffer_csv = None
 
         if df is not None:
-            buffer_csv = BytesIO()
+            buffer_csv = BytesIO(df.to_csv(index = False).encode()) 
             buffer_csv.name = file_path
-            df.to_csv(buffer_csv, index = False)
-            buffer_csv.seek(0)
 
         auth_query = '''
             query($filename: String!

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -738,11 +738,11 @@ class NumerAPI(base_api.Api):
         # write the pandas DataFrame as a binary buffer if provided
         buffer_csv = None
 
-        if not df is None:
-            file_path = "predictions.csv"
+        if df is not None:
             buffer_csv = BytesIO()
             buffer_csv.name = file_path
             df.to_csv(buffer_csv, index = False)
+            buffer_csv.seek(0)
 
         auth_query = '''
             query($filename: String!
@@ -767,7 +767,7 @@ class NumerAPI(base_api.Api):
         headers = {"x_compute_id": os.getenv("NUMERAI_COMPUTE_ID")}
         with open(file_path, 'rb') if df is None else buffer_csv as fh:
             requests.put(
-                submission_auth['url'], data=fh.read() if df is None else fh.getvalue(), headers=headers)
+                submission_auth['url'], data=fh.read(), headers=headers)
         create_query = '''
             mutation($filename: String!
                      $tournament: Int!

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -786,12 +786,12 @@ class NumerAPI(base_api.Api):
 
     def upload_predictions(self, df: pd.DataFrame, tournament: int = 8,
                            model_id: str = None) -> str:
-        """Upload predictions from file.
+        """Upload predictions from pandas DataFrame.
         Will read TRIGGER_ID from the environment if this model is enabled with
         a Numerai Compute cluster setup by Numerai CLI.
 
         Args:
-            file_path (str): Pandas DataFrame with predictions that will get uploaded
+            df (pandas.DataFrame): Pandas DataFrame with predictions that will get uploaded
             tournament (int): ID of the tournament (optional, defaults to 8)
                 -- DEPRECATED there is only one tournament nowadays
             model_id (str): Target model UUID (required for accounts with
@@ -803,7 +803,7 @@ class NumerAPI(base_api.Api):
         Example:
             >>> api = NumerAPI(secret_key="..", public_id="..")
             >>> model_id = api.get_models()['uuazed']
-            >>> api.upload_predictions("prediction.cvs", model_id=model_id)
+            >>> api.upload_predictions(submission_dataframe, model_id=model_id)
             '93c46857-fed9-4594-981e-82db2b358daf'
         """
         self.logger.info("uploading predictions...")

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -732,6 +732,10 @@ class NumerAPI(base_api.Api):
             >>> model_id = api.get_models()['uuazed']
             >>> api.upload_predictions("prediction.cvs", model_id=model_id)
             '93c46857-fed9-4594-981e-82db2b358daf'
+
+            >>> api = NumerAPI(secret_key="..", public_id="..")
+            >>> model_id = api.get_models()['uuazed']
+            >>> api.upload_predictions(df = predictions_df, model_id=model_id)
         """
         self.logger.info("uploading predictions...")
 

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -791,7 +791,7 @@ class NumerAPI(base_api.Api):
         a Numerai Compute cluster setup by Numerai CLI.
 
         Args:
-            file_path (str): CSV file with predictions that will get uploaded
+            file_path (str): Pandas DataFrame with predictions that will get uploaded
             tournament (int): ID of the tournament (optional, defaults to 8)
                 -- DEPRECATED there is only one tournament nowadays
             model_id (str): Target model UUID (required for accounts with

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -132,12 +132,12 @@ class SignalsAPI(base_api.Api):
         return create['data']['createSignalsSubmission']['id']
 
     def upload_predictions(self, df:pd.DataFrame, model_id: str = None) -> str:
-        """Upload predictions from file.
+        """Upload predictions from pandas DataFrame.
         Will read TRIGGER_ID from the environment if this model is enabled with
         a Numerai Compute cluster setup by Numerai CLI.
 
         Args:
-            file_path (str): CSV file with predictions that will get uploaded
+            df (pandas.DataFrame): Pandas DataFrame with predictions that will get uploaded
             model_id (str): Target model UUID (required for accounts
                             with multiple models)
 

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -97,11 +97,11 @@ class SignalsAPI(base_api.Api):
         # write the pandas DataFrame as a binary buffer if provided
         buffer_csv = None
 
-        if not df is None:
-            file_path = "predictions.csv"
+        if df is not None:
             buffer_csv = BytesIO()
             buffer_csv.name = file_path
             df.to_csv(buffer_csv, index = False)
+            buffer_csv.seek(0)
             #print(buffer_csv.getvalue())
             #print(buffer_csv.name)
 
@@ -129,7 +129,7 @@ class SignalsAPI(base_api.Api):
         
         # use the dataframe buffer to upload if it was provided otherwise open the filepath
         with open(file_path, 'rb') if df is None else buffer_csv as fh:
-            requests.put(auth['url'], data=fh.read() if df is None else fh.getvalue(), headers=headers)
+            requests.put(auth['url'], data=fh.read(), headers=headers)
         create_query = '''
             mutation($filename: String!
                      $modelId: String

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -147,7 +147,7 @@ class SignalsAPI(base_api.Api):
         Example:
             >>> api = SignalsAPI(secret_key="..", public_id="..")
             >>> model_id = api.get_models()['uuazed']
-            >>> api.upload_predictions("prediction.cvs", model_id=model_id)
+            >>> api.upload_predictions(submission_dataframe, model_id=model_id)
             '93c46857-fed9-4594-981e-82db2b358daf'
         """
         self.logger.info("uploading predictions...")

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -91,6 +91,10 @@ class SignalsAPI(base_api.Api):
             >>> model_id = api.get_models()['uuazed']
             >>> api.upload_predictions("prediction.cvs", model_id=model_id)
             '93c46857-fed9-4594-981e-82db2b358daf'
+
+            >>> api = SignalsAPI(secret_key="..", public_id="..")
+            >>> model_id = api.get_models()['uuazed']
+            >>> api.upload_predictions(df = predictions_df, model_id=model_id)
         """
         self.logger.info("uploading predictions...")
 

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -5,6 +5,7 @@ import codecs
 import decimal
 from io import BytesIO
 
+
 # Third Party
 import requests
 import pandas as pd
@@ -102,13 +103,8 @@ class SignalsAPI(base_api.Api):
         buffer_csv = None
 
         if df is not None:
-            buffer_csv = BytesIO()
+            buffer_csv = BytesIO(df.to_csv(index = False).encode()) 
             buffer_csv.name = file_path
-            df.to_csv(buffer_csv, index = False)
-            buffer_csv.seek(0)
-            #print(buffer_csv.getvalue())
-            #print(buffer_csv.name)
-
 
         auth_query = '''
             query($filename: String!

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -104,10 +104,8 @@ class SignalsAPI(base_api.Api):
         buffer_csv = None
 
         if df is not None:
-            buffer_csv = BytesIO()
+            buffer_csv = BytesIO(df.to_csv(index = False).encode()) 
             buffer_csv.name = file_path
-            df.to_csv(buffer_csv, index=False)
-            buffer_csv.seek(0)
 
         auth_query = '''
             query($filename: String!

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ python-dateutil
 pytz
 tqdm>=4.29.1
 click>=7.0
-pandas>=1.2.2
+pandas>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dateutil
 pytz
 tqdm>=4.29.1
 click>=7.0
+pandas>=1.2.2

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -3,3 +3,4 @@ pytest-cov
 codecov
 responses
 flake8
+pandas>=1.2.2

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -3,4 +3,4 @@ pytest-cov
 codecov
 responses
 flake8
-pandas>=1.2.2
+pandas>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         package_data={'numerai': ['LICENSE', 'README.md']},
         packages=find_packages(exclude=['tests']),
         install_requires=["requests", "pytz", "python-dateutil",
-                          "tqdm>=4.29.1", "click>=7.0"],
+                          "tqdm>=4.29.1", "click>=7.0","pandas>=1.2.2"],
         entry_points={
           'console_scripts': [
               'numerapi = numerapi.cli:cli'

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         package_data={'numerai': ['LICENSE', 'README.md']},
         packages=find_packages(exclude=['tests']),
         install_requires=["requests", "pytz", "python-dateutil",
-                          "tqdm>=4.29.1", "click>=7.0","pandas>=1.2.2"],
+                          "tqdm>=4.29.1", "click>=7.0","pandas>=1.1.0"],
         entry_points={
           'console_scripts': [
               'numerapi = numerapi.cli:cli'

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -4,6 +4,8 @@ import datetime
 import pytz
 import responses
 
+import pandas as pd
+
 import numerapi
 from numerapi import base_api
 
@@ -101,8 +103,16 @@ def test_upload_predictions(api, tmpdir):
     path = tmpdir.join("somefilepath")
     path.write("content")
     submission_id = api.upload_predictions(str(path))
+
+    df = pd.DataFrame.from_dict({"id":["a","b","c","d"],"prediction":[0.4,0.2,0.3,0.1]})
+    submission_id_df = api.upload_predictions(df = df)
+
+    assert submission_id_df == "1234"
+
     assert submission_id == "1234"
     assert len(responses.calls) == 3
+
+
 
 
 @responses.activate

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -104,13 +104,29 @@ def test_upload_predictions(api, tmpdir):
     path.write("content")
     submission_id = api.upload_predictions(str(path))
 
-    df = pd.DataFrame.from_dict({"id":["a","b","c","d"],"prediction":[0.4,0.2,0.3,0.1]})
-    submission_id_df = api.upload_predictions(df = df)
-
-    assert submission_id_df == "1234"
-
     assert submission_id == "1234"
     assert len(responses.calls) == 3
+
+#Test the dataframe uploading version of upload_predictions
+@responses.activate   
+def test_upload_predictions_df(api):
+
+    api.token = ("", "")
+
+    data = {"data": {"submission_upload_auth": {"url": "https://uploadurl",
+                                                "filename": "predictions.csv"}}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+    responses.add(responses.PUT, "https://uploadurl")
+    data = {"data": {"create_submission": {"id": "12345"}}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    df = pd.DataFrame.from_dict({"id":[],"prediction":[]})
+    submission_id = api.upload_predictions(df = df)
+
+    
+
+    assert len(responses.calls) == 3
+    assert submission_id == "12345"
 
 
 

--- a/tests/test_signalsapi.py
+++ b/tests/test_signalsapi.py
@@ -34,14 +34,26 @@ def test_upload_predictions(api, tmpdir):
     path.write("content")
     submission_id = api.upload_predictions(str(path))
 
-    df = pd.DataFrame.from_dict({"bloomberg_ticker":["a","b","c","d"],"signal":[0.4,0.2,0.3,0.1]})
-    submission_id_df = api.upload_predictions(df = df)
-
-    assert submission_id_df == "1234"
-
     assert submission_id == "1234"
     assert len(responses.calls) == 3
 
+#Test pandas.DataFrame version of upload_predictions
+@responses.activate
+def test_upload_predictions_df(api):
+    api.token = ("", "")
+    # we need to mock 3 network calls: 1. auth 2. file upload and 3. submission
+    data = {"data": {"submissionUploadSignalsAuth":
+            {"url": "https://uploadurl", "filename": "predictions.csv"}}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+    responses.add(responses.PUT, "https://uploadurl")
+    data = {"data": {"createSignalsSubmission": {"id": "12345"}}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    df = pd.DataFrame.from_dict({"bloomberg_ticker":[],"signal":[]})
+    submission_id = api.upload_predictions(df = df)
+
+    assert submission_id == "12345"
+    assert len(responses.calls) == 3
 
 @responses.activate
 def test_daily_submissions_performances(api):

--- a/tests/test_signalsapi.py
+++ b/tests/test_signalsapi.py
@@ -2,6 +2,8 @@ import pytest
 import datetime
 import responses
 
+import pandas as pd
+
 import numerapi
 from numerapi import base_api
 
@@ -31,6 +33,12 @@ def test_upload_predictions(api, tmpdir):
     path = tmpdir.join("somefilepath")
     path.write("content")
     submission_id = api.upload_predictions(str(path))
+
+    df = pd.DataFrame.from_dict({"bloomberg_ticker":["a","b","c","d"],"signal":[0.4,0.2,0.3,0.1]})
+    submission_id_df = api.upload_predictions(df = df)
+
+    assert submission_id_df == "1234"
+
     assert submission_id == "1234"
     assert len(responses.calls) == 3
 


### PR DESCRIPTION
Google colab has pandas 1.1.0 which is not compatible with the previous way of writing the DataFrame to memory and uploading to Numerai tournaments, replaced with new method of writing DataFrames to memory/upload that works on pandas 1.1.0, 1.1.5, 1.2.4 for signals and main (also assuming it will probably work anywhere inbetween 1.1.0 and 1.2.4).

Lowered pandas requirements for test and main module to version 1.1.0 or greater

passes pytest tests 49/49