### PR TITLE
Pandas version agnostic rewrite, now pandas>=1.1.0

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -744,10 +744,8 @@ class NumerAPI(base_api.Api):
         buffer_csv = None
 
         if df is not None:
-            buffer_csv = BytesIO()
+            buffer_csv = BytesIO(df.to_csv(index = False).encode()) 
             buffer_csv.name = file_path
-            df.to_csv(buffer_csv, index=False)
-            buffer_csv.seek(0)
 
         auth_query = '''
             query($filename: String!

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -104,10 +104,8 @@ class SignalsAPI(base_api.Api):
         buffer_csv = None
 
         if df is not None:
-            buffer_csv = BytesIO()
+            buffer_csv = BytesIO(df.to_csv(index = False).encode()) 
             buffer_csv.name = file_path
-            df.to_csv(buffer_csv, index=False)
-            buffer_csv.seek(0)
 
         auth_query = '''
             query($filename: String!

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ python-dateutil
 pytz
 tqdm>=4.29.1
 click>=7.0
-pandas>=1.2.2
+pandas>=1.1.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -3,4 +3,4 @@ pytest-cov
 codecov
 responses
 flake8
-pandas>=1.2.2
+pandas>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         package_data={'numerai': ['LICENSE', 'README.md']},
         packages=find_packages(exclude=['tests']),
         install_requires=["requests", "pytz", "python-dateutil",
-                          "tqdm>=4.29.1", "click>=7.0","pandas>=1.2.2"],
+                          "tqdm>=4.29.1", "click>=7.0","pandas>=1.1.0"],
         entry_points={
           'console_scripts': [
               'numerapi = numerapi.cli:cli'


### PR DESCRIPTION
Google colab has pandas 1.1.0 which is not compatible with the previous way of writing the DataFrame to memory, replaced with new method of writing DataFrames to memory that works on pandas 1.1.0, 1.1.5, 1.2.4 for signals and main (also assuming it will probably work anywhere inbetween 1.1.0 and 1.2.4).

Lowered pandas requirements for test and main module to version 1.1.0 or greater

passes pytest tests 49/49