### PR TITLE
Remove CLI 'payments' and 'user-activities' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ To get started with the cli interface, let's take a look at the help page:
       download-dataset                Download dataset for the current active...
       leaderboard                     Get the leaderboard.
       models                          Get map of account models!
-      payments                        List all your payments
       profile                         Fetch the public profile of a user.
       stake-decrease                  Decrease your stake by `value` NMR.
       stake-drain                     Completely remove your stake.
@@ -128,7 +127,6 @@ To get started with the cli interface, let's take a look at the help page:
       submit                          Upload predictions from file.
       transactions                    List all your deposits and withdrawals.
       user                            Get all information about you! DEPRECATED...
-      user-activities                 Get user activities (works for all users!)
       version                         Installed numerapi version.
 
 

--- a/numerapi/cli.py
+++ b/numerapi/cli.py
@@ -63,15 +63,6 @@ def leaderboard(limit=20, offset=0):
 
 
 @cli.command()
-@click.argument("username")
-@click.option('--tournament', default=8,
-              help='The ID of the tournament, defaults to 8')
-def user_activities(username, tournament=8):
-    """Get user activities (works for all users!)"""
-    click.echo(prettify(napi.get_user_activities(username, tournament)))
-
-
-@cli.command()
 @click.option('--tournament', type=int, default=None,
               help='filter by ID of the tournament, defaults to None')
 @click.option('--round_num', type=int, default=None,
@@ -137,15 +128,6 @@ def daily_user_performances(username):
 def daily_submissions_performances(username):
     """Fetch daily performance of a user's submissions."""
     click.echo(prettify(napi.daily_submissions_performances(username)))
-
-
-@cli.command()
-@click.option(
-    '--model_id', type=str, default=None,
-    help="An account model UUID (required for accounts with multiple models")
-def payments(model_id):
-    """List all your payments"""
-    click.echo(prettify(napi.get_payments(model_id)))
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,13 +51,6 @@ def test_current_round(mocked):
     assert result.exit_code == 0
 
 
-@patch('numerapi.NumerAPI.get_user_activities')
-def test_user_activities(mocked, login):
-    result = CliRunner().invoke(cli.user_activities, 'username')
-    # just testing if calling works fine
-    assert result.exit_code == 0
-
-
 @patch('numerapi.NumerAPI.get_submission_filenames')
 def test_submission_filenames(mocked):
     result = CliRunner().invoke(cli.submission_filenames, ['--tournament', 1])
@@ -93,13 +86,6 @@ def test_user(mocked, login):
 @patch('numerapi.NumerAPI.get_user')
 def test_user_with_model_id(mocked, login):
     result = CliRunner().invoke(cli.user, ['--model_id', '31a42870-38b6-4435-ad49-18b987ff4148'])
-    # just testing if calling works fine
-    assert result.exit_code == 0
-
-@patch('numerapi.NumerAPI.get_payments')
-def test_payments(mocked, login):
-    result = CliRunner().invoke(cli.payments,
-                                ['--model_id', '31a42870-38b6-4435-ad49-18b987ff4148'])
     # just testing if calling works fine
     assert result.exit_code == 0
 

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -67,7 +67,7 @@ def test_get_current_round(api):
 
 
 @pytest.mark.parametrize("fun", ["get_user", "get_account",
-                                 "get_transactions", "get_payments"])
+                                 "get_transactions"])
 def test_unauthorized_requests(api, fun):
     with pytest.raises(ValueError) as err:
         # while this won't work because we are not authorized, it still tells


### PR DESCRIPTION
Removes deprecated calls to `get_payments` and `get_user_activities`
(removed here https://github.com/uuazed/numerapi/commit/b9346b76b0ddc576ecca3e8371d57889a56e52ab)