### PR TITLE
Accept --json flag converting the output to JSON when using CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ To get started with the cli interface, let's take a look at the help page:
       Wrapper around the Numerai API
 
     Options:
-      --json  Output JSON instead of Dict.
       --help  Show this message and exit.
 
     Commands:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ To get started with the cli interface, let's take a look at the help page:
       Wrapper around the Numerai API
 
     Options:
+      --json  Output JSON instead of Dict.
       --help  Show this message and exit.
 
     Commands:
@@ -116,7 +117,6 @@ To get started with the cli interface, let's take a look at the help page:
       download-dataset                Download dataset for the current active...
       leaderboard                     Get the leaderboard.
       models                          Get map of account models!
-      payments                        List all your payments
       profile                         Fetch the public profile of a user.
       stake-decrease                  Decrease your stake by `value` NMR.
       stake-drain                     Completely remove your stake.
@@ -128,7 +128,6 @@ To get started with the cli interface, let's take a look at the help page:
       submit                          Upload predictions from file.
       transactions                    List all your deposits and withdrawals.
       user                            Get all information about you! DEPRECATED...
-      user-activities                 Get user activities (works for all users!)
       version                         Installed numerapi version.
 
 

--- a/numerapi/cli.py
+++ b/numerapi/cli.py
@@ -1,4 +1,3 @@
-import pprint
 import click
 import json
 import datetime
@@ -12,7 +11,7 @@ napi = numerapi.NumerAPI()
 class CommonJSONEncoder(json.JSONEncoder):
     """
     Common JSON Encoder
-    json.dumps(myString, cls=CommonJSONEncoder)
+    json.dumps(jsonString, cls=CommonJSONEncoder)
     """
     def default(self, obj):
         """Encode: Decimal"""
@@ -24,27 +23,14 @@ class CommonJSONEncoder(json.JSONEncoder):
         pass
 
 
-"""
-When True (set in cli(json)), instructs the CLI to output JSON instead of Dictionary
-(used long name to prevent collisions)
-"""
-numerapi_cli_output_json_flag=False
-
-
 def prettify(stuff):
-    pp = pprint.PrettyPrinter(indent=4)
-    if numerapi_cli_output_json_flag:
-      return json.dumps(stuff, cls=CommonJSONEncoder, indent=4)
-    return pp.pformat(stuff)
+    return json.dumps(stuff, cls=CommonJSONEncoder, indent=4)
 
 
 @click.group()
-@click.option('--json', type=bool, is_flag=True, default=False,
-              help='Output JSON instead of Dict.')
-def cli(json=False):
+def cli():
     """Wrapper around the Numerai API"""
-    global numerapi_cli_output_json_flag
-    numerapi_cli_output_json_flag=json
+    pass
 
 
 @cli.command()

--- a/numerapi/cli.py
+++ b/numerapi/cli.py
@@ -1,20 +1,50 @@
 import pprint
 import click
+import json
+import datetime
+import decimal
 
 import numerapi
 
 napi = numerapi.NumerAPI()
 
 
+class CommonJSONEncoder(json.JSONEncoder):
+    """
+    Common JSON Encoder
+    json.dumps(myString, cls=CommonJSONEncoder)
+    """
+    def default(self, obj):
+        """Encode: Decimal"""
+        if isinstance(obj, decimal.Decimal):
+            return str(obj)
+        """Encode: Date & Datetime"""
+        if isinstance(obj, (datetime.date, datetime.datetime)):
+          return obj.isoformat()
+        pass
+
+
+"""
+When True (set in cli(json)), instructs the CLI to output JSON instead of Dictionary
+(used long name to prevent collisions)
+"""
+numerapi_cli_output_json_flag=False
+
+
 def prettify(stuff):
     pp = pprint.PrettyPrinter(indent=4)
+    if numerapi_cli_output_json_flag:
+      return json.dumps(stuff, cls=CommonJSONEncoder, indent=4)
     return pp.pformat(stuff)
 
 
 @click.group()
-def cli():
+@click.option('--json', type=bool, is_flag=True, default=False,
+              help='Output JSON instead of Dict.')
+def cli(json=False):
     """Wrapper around the Numerai API"""
-    pass
+    global numerapi_cli_output_json_flag
+    numerapi_cli_output_json_flag=json
 
 
 @cli.command()


### PR DESCRIPTION
P.S. Feel free to edit or ignore this PR if the lack of tests or the use case concern you in anyway. I run across an issue with parsing the  CLI output as JSON and decide to send a PR with my own solution.

# Current situation
Getting tournament information via the CLI outputs the data as a dictionary. Some of the endpoints return data that is easily parsable as JSON. But once the API returns dates or decimal values, then JSON prrsers are failing.  For example, here `startDate` has an invalid JSON value:

```
numerapi profile integration_test

# outputs:
{   'bio': 'The official example model. Submits example predictions.',
    'id': '59de8728-38e5-45bd-a3d5-9d4ad649dd3f',
    'startDate': datetime.datetime(2018, 6, 6, 17, 33, 21, tzinfo=tzutc()),
    'totalStake': '60.181006030114101196',
    'username': 'integration_test'}
```

# Desired situation
Accept an `--json` argument that converts the dictionary to JSON format:

```
numerapi --json profile integration_test

# outputs:
{
    "bio": "The official example model. Submits example predictions.",
    "id": "59de8728-38e5-45bd-a3d5-9d4ad649dd3f",
    "startDate": "2018-06-06T17:33:21+00:00",
    "totalStake": "60.181006030114101196",
    "username": "integration_test"
}
```

In this case, values like `datetime` and `decimal.Decimal` are converted to something that JSON parsers like `jq` can handle.