### PR TITLE
add query names, new profile endpoints

### DIFF
--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -167,7 +167,7 @@ class Api:
              }
         """
         query = """
-          query {
+          query napi_getAccount{
             account {
               username
               walletAddress
@@ -218,7 +218,7 @@ class Api:
             {'uuazed': '9b157d9b-ce61-4ab5-9413-413f13a0c0a6'}
         """
         query = """
-          query {
+          query napi_getModels{
             account {
               models {
                 id
@@ -255,7 +255,7 @@ class Api:
             tournament = self.tournament_id
         # zero is an alias for the current round!
         query = '''
-            query($tournament: Int!) {
+            query napi_getCurrentRound($tournament: Int!) {
               rounds(tournament: $tournament
                      number: 0) {
                 number
@@ -317,7 +317,7 @@ class Api:
                  .. ]}
         """
         query = """
-          query {
+          query napi_getAccountTransactions{
             account {
               nmrDeposits {
                 from
@@ -426,7 +426,7 @@ class Api:
         self.logger.warning(
             "get_transactions is DEPRECATED, use get_account_transactions")
         query = """
-          query($modelId: String) {
+          query napi_getTransactions($modelId: String) {
             user(modelId: $modelId) {
               nmrDeposits {
                 from
@@ -495,7 +495,7 @@ class Api:
             True
         """
         query = '''
-          mutation (
+          mutation napi_setSubmissionWebhook (
             $modelId: String!
             $newSubmissionWebhook: String
           ) {

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -140,3 +140,13 @@ def test_check_new_round(api):
     assert api.check_new_round()
     # second
     assert not api.check_new_round()
+
+
+def test_user_profile_v2(api):
+    profile = api.public_user_profile_v2("integration_test")
+    assert profile["username"] == "integration_test"
+
+
+def test_daily_model_performances(api):
+    performances = api.public_user_profile_v2("integration_test")
+    assert len(performances) > 0

--- a/tests/test_signalsapi.py
+++ b/tests/test_signalsapi.py
@@ -90,3 +90,13 @@ def test_ticker_universe(api):
     result = api.ticker_universe()
     assert "bloomberg_ticker" not in result
     assert len(result) == 3
+
+
+def test_user_profile_v2(api):
+    profile = api.public_user_profile_v2("integration_test")
+    assert profile["username"] == "integration_test"
+
+
+def test_daily_model_performances(api):
+    performances = api.public_user_profile_v2("integration_test")
+    assert len(performances) > 0


### PR DESCRIPTION
Query names are needed to help us monitor backend performance (since graphql queries all go to the same endpoint).

Also added a couple new methods to use the new v3UserProfile and v2SignalsProfile endpoints