### PR TITLE
added 20d stats to SignalsAPI.daily_user_performances

### DIFF
--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -298,10 +298,13 @@ class SignalsAPI(base_api.Api):
             signalsUserProfile(username: $username) {
               dailyUserPerformances {
                 rank
+                corr20dRank
                 date
                 sharpe
                 mmcRep
+                mmc20dRep
                 reputation
+                corr20dRep
               }
             }
           }


### PR DESCRIPTION
Hi,

This pull request is for adding 20d info to daily_user_performances, given that Numerai is now switching to 20d.

Please note, an unrelated test for numerapi `tests/test_numerapi.py::test_get_competitions` is failing due to the following error `ValueError: Cannot query field "ruleset" on type "Round". Did you mean "resolveTime"?`
It also fails in master branch.

Will be glad if this PR will be merged soon.