### PR TITLE
refactor: improve type hints

### DIFF
--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -3,7 +3,6 @@
 import os
 import datetime
 import logging
-from typing import Dict, List
 from io import BytesIO
 import pytz
 
@@ -73,7 +72,7 @@ class Api:
                 self.logger.error(msg)
         return msg
 
-    def raw_query(self, query: str, variables: Dict = None,
+    def raw_query(self, query: str, variables: dict = None,
                   authorization: bool = False,
                   retries: int = 3, delay: int = 5, backoff: int = 2):
         """Send a raw request to the Numerai's GraphQL API.
@@ -132,7 +131,7 @@ class Api:
             raise ValueError(err)
         return result
 
-    def get_account(self) -> Dict:
+    def get_account(self) -> dict:
         """Get all information about your account!
 
         Returns:
@@ -214,7 +213,7 @@ class Api:
         utils.replace(data, "availableNmr", utils.parse_float_string)
         return data
 
-    def get_models(self, tournament: int = None) -> Dict:
+    def get_models(self, tournament: int = None) -> dict:
         """Get mapping of account model names to model ids for convenience
 
         Args:
@@ -280,7 +279,7 @@ class Api:
         round_num = data["number"]
         return round_num
 
-    def get_account_transactions(self) -> List:
+    def get_account_transactions(self) -> list:
         """Get all your account deposits and withdrawals.
 
         DEPRECATED - please use `wallet_transactions` instead"
@@ -346,7 +345,7 @@ class Api:
         res = self.raw_query(mutation, args, authorization=True)
         return res["data"]["setUserLink"]
 
-    def wallet_transactions(self) -> List:
+    def wallet_transactions(self) -> list:
         """Get all transactions in your wallet.
 
         Returns:
@@ -434,7 +433,7 @@ class Api:
         return res['data']['setSubmissionWebhook'] == "true"
 
     def _upload_auth(self, endpoint: str, file_path: str, tournament: int,
-                     model_id: str) -> Dict[str, str]:
+                     model_id: str) -> dict[str, str]:
         auth_query = f'''
             query($filename: String!
                   $tournament: Int!
@@ -513,7 +512,7 @@ class Api:
         diagnostics_id = create['data']['createDiagnostics']['id']
         return diagnostics_id
 
-    def diagnostics(self, model_id: str, diagnostics_id: str = None) -> Dict:
+    def diagnostics(self, model_id: str, diagnostics_id: str = None) -> dict:
         """Fetch results of diagnostics run
 
         Args:
@@ -629,7 +628,7 @@ class Api:
         utils.replace(results, "updatedAt", utils.parse_datetime_string)
         return results
 
-    def round_model_performances(self, username: str) -> List[Dict]:
+    def round_model_performances(self, username: str) -> list[dict]:
         """Fetch round model performance of a user.
 
         Args:
@@ -758,7 +757,7 @@ class Api:
         return performances
 
     def stake_change(self, nmr, action: str = "decrease",
-                     model_id: str = None) -> Dict:
+                     model_id: str = None) -> dict:
         """Change stake by `value` NMR.
 
         Args:
@@ -810,7 +809,7 @@ class Api:
         utils.replace(stake, "dueDate", utils.parse_datetime_string)
         return stake
 
-    def stake_drain(self, model_id: str = None) -> Dict:
+    def stake_drain(self, model_id: str = None) -> dict:
         """Completely remove your stake.
 
         Args:
@@ -838,7 +837,7 @@ class Api:
         """
         return self.stake_decrease(11000000, model_id)
 
-    def stake_decrease(self, nmr, model_id: str = None) -> Dict:
+    def stake_decrease(self, nmr, model_id: str = None) -> dict:
         """Decrease your stake by `value` NMR.
 
         Args:
@@ -867,7 +866,7 @@ class Api:
         """
         return self.stake_change(nmr, 'decrease', model_id)
 
-    def stake_increase(self, nmr, model_id: str = None) -> Dict:
+    def stake_increase(self, nmr, model_id: str = None) -> dict:
         """Increase your stake by `value` NMR.
 
         Args:
@@ -899,7 +898,7 @@ class Api:
     def set_stake_type(self, model_id: str = None,
                        corr_multiplier: int = 0,
                        tc_multiplier: float = 0,
-                       take_profit: bool = False) -> Dict:
+                       take_profit: bool = False) -> dict:
         """Change stake type by model.
 
         Args:

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -3,7 +3,6 @@
 import zipfile
 import os
 import decimal
-from typing import List, Dict
 from io import BytesIO
 
 import requests
@@ -46,7 +45,7 @@ class NumerAPI(base_api.Api):
 
         return True
 
-    def list_datasets(self, round_num: int = None) -> List[str]:
+    def list_datasets(self, round_num: int = None) -> list[str]:
         """List of available data files
 
         Args:
@@ -307,7 +306,7 @@ class NumerAPI(base_api.Api):
         return rounds
 
     def get_submission_filenames(self, tournament=None, round_num=None,
-                                 model_id=None) -> List[Dict]:
+                                 model_id=None) -> list[dict]:
         """Get filenames of the submission of the user.
 
         Args:
@@ -365,7 +364,7 @@ class NumerAPI(base_api.Api):
         filenames.sort(key=lambda f: (f['round_num'], f['tournament']))
         return filenames
 
-    def get_user(self, model_id: str = None) -> Dict:
+    def get_user(self, model_id: str = None) -> dict:
         """Get all information about you! DEPRECATED
 
         Args:
@@ -453,7 +452,7 @@ class NumerAPI(base_api.Api):
         utils.replace(data, "availableNmr", utils.parse_float_string)
         return data
 
-    def submission_status(self, model_id: str = None) -> Dict:
+    def submission_status(self, model_id: str = None) -> dict:
         """submission status of the last submission associated with the account
 
         Args:
@@ -615,7 +614,7 @@ class NumerAPI(base_api.Api):
         submission_id = create['data']['create_submission']['id']
         return submission_id
 
-    def get_leaderboard(self, limit: int = 50, offset: int = 0) -> List[Dict]:
+    def get_leaderboard(self, limit: int = 50, offset: int = 0) -> list[dict]:
         """Get the current leaderboard
 
         Args:
@@ -678,7 +677,7 @@ class NumerAPI(base_api.Api):
             utils.replace(item, "nmrStaked", utils.parse_float_string)
         return data
 
-    def stake_set(self, nmr, model_id: str) -> Dict:
+    def stake_set(self, nmr, model_id: str) -> dict:
         """Set stake to value by decreasing or increasing your current stake
 
         Args:
@@ -756,7 +755,7 @@ class NumerAPI(base_api.Api):
         stake = data['dailyUserPerformances'][0]['stakeValue']
         return stake
 
-    def public_user_profile(self, username: str) -> Dict:
+    def public_user_profile(self, username: str) -> dict:
         """Fetch the public profile of a user.
 
         Args:
@@ -798,13 +797,13 @@ class NumerAPI(base_api.Api):
         utils.replace(data, "startDate", utils.parse_datetime_string)
         return data
 
-    def daily_user_performances(self, username: str) -> List[Dict]:
+    def daily_user_performances(self, username: str) -> list[dict]:
         """DEPRECATED"""
         self.logger.warning("Method daily_user_performances is DEPRECATED, "
                             "use daily_model_performances")
         return self.daily_model_performances(username)
 
-    def daily_model_performances(self, username: str) -> List[Dict]:
+    def daily_model_performances(self, username: str) -> list[dict]:
         """Fetch daily performance of a user.
 
         Args:
@@ -872,7 +871,7 @@ class NumerAPI(base_api.Api):
             utils.replace(perf, "date", utils.parse_datetime_string)
         return performances
 
-    def round_details(self, round_num: int) -> List[Dict]:
+    def round_details(self, round_num: int) -> list[dict]:
         """Fetch all correlation scores of a round.
 
         Args:
@@ -916,7 +915,7 @@ class NumerAPI(base_api.Api):
             utils.replace(perf, "date", utils.parse_datetime_string)
         return performances
 
-    def daily_submissions_performances(self, username: str) -> List[Dict]:
+    def daily_submissions_performances(self, username: str) -> list[dict]:
         """Fetch daily performance of a user's submissions.
 
         DEPRECATED - please use `daily_model_performances` instead"

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -1,6 +1,5 @@
 """API for Numerai Signals"""
 
-from typing import List, Dict
 import os
 import codecs
 import decimal
@@ -24,7 +23,7 @@ class SignalsAPI(base_api.Api):
         base_api.Api.__init__(self, *args, **kwargs)
         self.tournament_id = 11
 
-    def get_leaderboard(self, limit: int = 50, offset: int = 0) -> List[Dict]:
+    def get_leaderboard(self, limit: int = 50, offset: int = 0) -> list[dict]:
         """Get the current Numerai Signals leaderboard
         Args:
             limit (int): number of items to return (optional, defaults to 50)
@@ -161,7 +160,7 @@ class SignalsAPI(base_api.Api):
         create = self.raw_query(create_query, arguments, authorization=True)
         return create['data']['createSignalsSubmission']['id']
 
-    def submission_status(self, model_id: str = None) -> Dict:
+    def submission_status(self, model_id: str = None) -> dict:
         """submission status of the last submission associated with the account
 
         Args:
@@ -229,7 +228,7 @@ class SignalsAPI(base_api.Api):
         status = data['data']['model']['latestSignalsSubmission']
         return status
 
-    def public_user_profile(self, username: str) -> Dict:
+    def public_user_profile(self, username: str) -> dict:
         """Fetch the public Numerai Signals profile of a user.
 
         Args:
@@ -272,7 +271,7 @@ class SignalsAPI(base_api.Api):
         utils.replace(data, "nmrStaked", utils.parse_float_string)
         return data
 
-    def daily_model_performances(self, username: str) -> List[Dict]:
+    def daily_model_performances(self, username: str) -> list[dict]:
         """Fetch daily Numerai Signals performance of a model.
 
         Args:
@@ -349,7 +348,7 @@ class SignalsAPI(base_api.Api):
             utils.replace(perf, "date", utils.parse_datetime_string)
         return performances
 
-    def daily_user_performances(self, username: str) -> List[Dict]:
+    def daily_user_performances(self, username: str) -> list[dict]:
         """DEPRECATED Fetch daily Numerai Signals performance of a user.
 
         Args:
@@ -401,7 +400,7 @@ class SignalsAPI(base_api.Api):
             utils.replace(perf, "date", utils.parse_datetime_string)
         return performances
 
-    def daily_submissions_performances(self, username: str) -> List[Dict]:
+    def daily_submissions_performances(self, username: str) -> list[dict]:
         """Fetch daily Numerai Signals performance of a user's submissions.
 
         Args:
@@ -468,7 +467,7 @@ class SignalsAPI(base_api.Api):
             utils.replace(perf, "submissionTime", utils.parse_datetime_string)
         return performances
 
-    def ticker_universe(self) -> List[str]:
+    def ticker_universe(self) -> list[str]:
         """fetch universe of accepted tickers
 
         Returns:

--- a/numerapi/utils.py
+++ b/numerapi/utils.py
@@ -6,6 +6,7 @@ import logging
 import time
 import datetime
 import json
+from typing import Optional
 
 import dateutil.parser
 import requests
@@ -14,14 +15,14 @@ import tqdm
 logger = logging.getLogger(__name__)
 
 
-def parse_datetime_string(string: str) -> datetime.datetime | None:
+def parse_datetime_string(string: str) -> Optional[datetime.datetime]:
     """try to parse string to datetime object"""
     if string is None:
         return None
     return dateutil.parser.parse(string)
 
 
-def parse_float_string(string: str) -> float | None:
+def parse_float_string(string: str) -> Optional[float]:
     """try to parse string to decimal.Decimal object"""
     if string is None:
         return None
@@ -89,7 +90,7 @@ def download_file(url: str, dest_path: str, show_progress_bars: bool = True):
 
 
 def post_with_err_handling(url: str, body: str, headers: dict,
-                           timeout: int | None = None,
+                           timeout: Optional[int] = None,
                            retries: int = 3, delay: int = 1, backoff: int = 2
                            ) -> dict:
     """send `post` request and handle (some) errors that might occur"""

--- a/numerapi/utils.py
+++ b/numerapi/utils.py
@@ -6,7 +6,6 @@ import logging
 import time
 import datetime
 import json
-from typing import Optional, Dict
 
 import dateutil.parser
 import requests
@@ -15,14 +14,14 @@ import tqdm
 logger = logging.getLogger(__name__)
 
 
-def parse_datetime_string(string: str) -> Optional[datetime.datetime]:
+def parse_datetime_string(string: str) -> datetime.datetime | None:
     """try to parse string to datetime object"""
     if string is None:
         return None
     return dateutil.parser.parse(string)
 
 
-def parse_float_string(string: str) -> Optional[float]:
+def parse_float_string(string: str) -> float | None:
     """try to parse string to decimal.Decimal object"""
     if string is None:
         return None
@@ -33,7 +32,7 @@ def parse_float_string(string: str) -> Optional[float]:
     return val
 
 
-def replace(dictionary: Dict, key: str, function):
+def replace(dictionary: dict, key: str, function):
     """apply a function to dict item"""
     if dictionary is not None and key in dictionary:
         dictionary[key] = function(dictionary[key])
@@ -89,10 +88,10 @@ def download_file(url: str, dest_path: str, show_progress_bars: bool = True):
     return dest_path
 
 
-def post_with_err_handling(url: str, body: str, headers: Dict,
-                           timeout: Optional[int] = None,
+def post_with_err_handling(url: str, body: str, headers: dict,
+                           timeout: int | None = None,
                            retries: int = 3, delay: int = 1, backoff: int = 2
-                           ) -> Dict:
+                           ) -> dict:
     """send `post` request and handle (some) errors that might occur"""
     try:
         resp = requests.post(url, json=body, headers=headers, timeout=timeout)


### PR DESCRIPTION
As of Python 3.9, it is possible to address type hints via built-in keywords for common types.

List, Dict -> list, dict etc.

See PEP 585 – Type Hinting Generics In Standard Collections for more details.