### PR TITLE
feat: adjust connection timeout upload prediction

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -3,7 +3,7 @@
 import zipfile
 import os
 import decimal
-from typing import List, Dict
+from typing import List, Dict, Tuple, Union
 from io import BytesIO
 
 import requests
@@ -551,7 +551,9 @@ class NumerAPI(base_api.Api):
                            tournament: int = 8,
                            model_id: str = None,
                            df: pd.DataFrame = None,
-                           data_datestamp: int = None) -> str:
+                           data_datestamp: int = None,
+                           timeout: Union[None, float, Tuple[float, float]] = (10, 600),
+    ) -> str:
         """Upload predictions from file.
         Will read TRIGGER_ID from the environment if this model is enabled with
         a Numerai Compute cluster setup by Numerai CLI.
@@ -595,7 +597,7 @@ class NumerAPI(base_api.Api):
         with open(file_path, 'rb') if df is None else buffer_csv as file:
             requests.put(
                 upload_auth['url'], data=file.read(), headers=headers,
-                timeout=600)
+                timeout=timeout)
         create_query = '''
             mutation($filename: String!
                      $tournament: Int!

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -568,6 +568,8 @@ class NumerAPI(base_api.Api):
                 given df and file_path, df will be uploaded.
             data_datestamp (int): Data lag, in case submission is done using
                 data from the previous day(s).
+            timeout (float|tuple(float,float)): waiting time (connection timeout,
+                read timeout)
 
         Returns:
             str: submission_id

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -1,6 +1,6 @@
 """API for Numerai Signals"""
 
-from typing import List, Dict
+from typing import List, Dict, Tuple, Union
 import os
 import codecs
 import decimal
@@ -86,7 +86,9 @@ class SignalsAPI(base_api.Api):
 
     def upload_predictions(self, file_path: str = "predictions.csv",
                            model_id: str = None,
-                           df: pd.DataFrame = None) -> str:
+                           df: pd.DataFrame = None,
+                           timeout: Union[None, float, Tuple[float, float]] = (10, 60),
+    ) -> str:
         """Upload predictions from file.
         Will read TRIGGER_ID from the environment if this model is enabled with
         a Numerai Compute cluster setup by Numerai CLI.
@@ -141,7 +143,7 @@ class SignalsAPI(base_api.Api):
 
         with open(file_path, 'rb') if df is None else buffer_csv as file:
             requests.put(auth['url'], data=file.read(),
-                         headers=headers, timeout=60)
+                         headers=headers, timeout=timeout)
         create_query = '''
             mutation($filename: String!
                      $modelId: String

--- a/numerapi/signalsapi.py
+++ b/numerapi/signalsapi.py
@@ -99,6 +99,8 @@ class SignalsAPI(base_api.Api):
                             with multiple models)
             df (pandas.DataFrame): Pandas DataFrame to upload, if function is
                 given df and file_path, df will be uploaded
+            timeout (float|tuple(float,float)): waiting time (connection timeout,
+                read timeout)
 
         Returns:
             str: submission_id


### PR DESCRIPTION
- Currently, we need to wait 600/60 sec for numerai/signals when connection or read timeout happens and the timeout is hardcoded for uploading prediction
- But from my experience, waiting connection timeout for a longer time may not help.
- And waiting 600sec (10mins) makes harder to manage retrying using server less solutions (such as aws lambda/gcp cloud run)
- Therefore, I would like to set a custom connection/read timeout

ref. https://github.com/psf/requests/blob/main/requests/sessions.py#L538-L541