### PR TITLE
stake_set() broken

### DIFF
--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -716,7 +716,7 @@ class NumerAPI(base_api.Api):
              'value': '10'}
         """
         # fetch current stake
-        current = self.stake_get(model_id)
+        current = self.stake_get(model_id) ### <<<--- BROKEN CODE --- 
         # convert everything to decimals
         if current is None:
             current = decimal.Decimal(0)


### PR DESCRIPTION
#The function stake_get() should receive "modelname" not "model_id" as the argument. As of now stake_set() is broken because it always receives the wrong argument. Either change get_stake() to take model_id as the argument, or retrieve the stake amount some other way .