### PR TITLE
Exchange `os.rename` for `os.replace`

### DIFF
--- a/numerapi/utils.py
+++ b/numerapi/utils.py
@@ -85,7 +85,7 @@ def download_file(url: str, dest_path: str, show_progress_bars: bool = True):
             dest_file.write(chunk)
             pbar.update(1024)
     # move temp file to target destination
-    os.rename(temp_path, dest_path)
+    os.replace(temp_path, dest_path)
     return dest_path
 
 


### PR DESCRIPTION
`os.rename` does not allow for replacing a file that already exists.  That doesn't seem to be the intent here, as it's downloading data that is likely to have the same destination filename in some pipelines - hence checking the file size and using '.temp' when downloading, so functional files don't get ruined by partial downloads.

https://stackoverflow.com/a/35202735