### PR TITLE
feat: add corr20V2 into round_model_performances

### DIFF
--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -718,6 +718,8 @@ class Api:
             content:
 
                 * corr (`float`)
+                * corr20V2 (`float` or None)
+                * corr20V2Percentile (`float` or None)
                 * corr20d (`float` or None)
                 * corr20dPercentile (`float` or None)
                 * corrMultiplier (`float`)
@@ -749,6 +751,8 @@ class Api:
             >>> api = NumerAPI()
             >>> api.round_model_performances("uuazed")
             [{'corr': -0.01296840448965,
+             'corr20V2': None,
+             'corr20V2Percentile': None,
              'corr20d': None,
              'corr20dPercentile': None,
              'corrMultiplier': 1.0,
@@ -791,6 +795,8 @@ class Api:
             {endpoint}(modelName: $username) {{
               roundModelPerformances {{
                 corr
+                corr20V2
+                corr20V2Percentile
                 corr20d
                 corr20dPercentile
                 corrMultiplier


### PR DESCRIPTION
Context:
- Numerai recently [introduced CORR20V2 as a new score](https://forum.numer.ai/t/target-cyrus-new-primary-target/6303)
- For Numerai, payouts will switch to CORR20V2 on May 13
- I would like to fetch CORR20V2 score for my model 

Changes:
- add `corr20V2` and `corr20V2Percentile` into `round_model_performances()`