### PR TITLE
Add tournament id arg to the download_dataset function

### DIFF
--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -189,12 +189,14 @@ class Api:
 
         query = """
         query ($filename: String!
-               $round: Int) {
+               $round: Int
+               $tournament: Int) {
             dataset(filename: $filename
-                    round: $round)
+                    round: $round
+                    tournament: $tournament)
         }
         """
-        args = {'filename': filename, "round": round_num}
+        args = {'filename': filename, "round": round_num, "tournament": self.tournament_id}
 
         dataset_url = self.raw_query(query, args)['data']['dataset']
         utils.download_file(dataset_url, dest_path, self.show_progress_bars)


### PR DESCRIPTION
**Context**:
discord message from ark:
Ah I see the issue, this is a simple oversight in the dataset api code: you actually shouldn't need to add the round name to the file, you just need to specify the tournament number. So this code should work:
```
api.raw_query(
  """
    query ($filename: String!
          $round: Int
          $tournament: Int) {
        dataset(filename: $filename
                round: $round
                tournament: $tournament)
    }
  """,
  variables={
    'filename': 'v1.0/live_universe.parquet',
    'round': round_nr,
    'tournament': 12
  }
)
```

**Changes suggested in this PR**:
- add the `tournament` argument to the raw_query which takes in value from the `self.tournament_id` instance variable.