### PR TITLE
v2.23.0 - V3 Stakes, Submission Scores, Rounds

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
       - name: Install pypa/build
@@ -26,6 +26,6 @@ jobs:
           python setup.py sdist && python setup.py bdist_wheel
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -383,6 +383,211 @@ class Api:
         }
         return mapping
 
+    def v3_stake_auth(
+        self,
+        submission_id: str,
+        staker: str,
+        amount: float | str | None = None,
+        max_amount: float | str | None = None,
+    ) -> Dict:
+        """Issue a staking v3 authorization for a selected submission.
+
+        Args:
+            submission_id (str): submission id for the selected submission
+            staker (str): staker wallet address
+            amount (float or str, optional): max stake amount for the
+                authorization. Retained as a backwards-compatible alias for
+                `max_amount`.
+            max_amount (float or str, optional): max stake amount for the
+                authorization.
+
+        Returns:
+            dict: authorization payload with the following fields:
+
+                * authorizationSigner (`str`)
+                * authorizationDigest (`str`)
+                * chainId (`str`)
+                * deadline (`str`)
+                * maxAmount (`str`)
+                * amount (`str`) alias for `maxAmount`
+                * modelId (`str`)
+                * nmrAddress (`str`)
+                * nonce (`str`)
+                * roundId (`str`)
+                * signature (`str`)
+                * staker (`str`)
+                * stakingAddress (`str`)
+                * submissionId (`str`)
+                * submissionHash (`str`)
+                * tournamentId (`str`)
+        """
+        if (amount is None) == (max_amount is None):
+            raise ValueError("Provide exactly one of amount or max_amount.")
+
+        max_amount = max_amount if max_amount is not None else amount
+        query = """
+          mutation($submissionId: ID!, $staker: String!, $maxAmount: String!) {
+            v3StakeAuth(
+              submissionId: $submissionId
+              staker: $staker
+              maxAmount: $maxAmount
+            ) {
+              authorizationSigner
+              authorizationDigest
+              chainId
+              deadline
+              maxAmount
+              modelId
+              nmrAddress
+              nonce
+              roundId
+              signature
+              staker
+              stakingAddress
+              submissionId
+              submissionHash
+              tournamentId
+            }
+          }
+        """
+        arguments = {
+            "submissionId": submission_id,
+            "staker": staker,
+            "maxAmount": str(max_amount),
+        }
+        authorization = self.raw_query(query, arguments, authorization=True)["data"][
+            "v3StakeAuth"
+        ]
+        authorization["amount"] = authorization["maxAmount"]
+        return authorization
+
+    def v3_stake_config(self) -> Dict:
+        """Fetch staking v3 contract configuration.
+
+        Returns:
+            dict: staking v3 configuration with the following fields:
+
+                * address (`str`)
+                * authorizationSigner (`str`)
+                * nmrAddress (`str`)
+                * owner (`str`)
+                * paused (`bool`)
+                * pendingOwner (`str`)
+                * serviceWallet (`str`)
+        """
+        query = """
+          query {
+            v3StakeConfig {
+              address
+              authorizationSigner
+              nmrAddress
+              owner
+              paused
+              pendingOwner
+              serviceWallet
+            }
+          }
+        """
+        return self.raw_query(query, authorization=True)["data"]["v3StakeConfig"]
+
+    def v3_stake_round(self, round_id: int | str) -> Dict:
+        """Fetch staking v3 round status by round id.
+
+        Args:
+            round_id (int or str): round id
+
+        Returns:
+            dict: staking v3 round data with the following fields:
+
+                * closeTime (`str`)
+                * merkleRoot (`str`)
+                * openTime (`str`)
+                * payoutFactor (`str`)
+                * remainingBurn (`str`)
+                * remainingPayout (`str`)
+                * resolveTime (`str`)
+                * resolved (`bool`)
+                * roundId (`str`)
+                * stakeCap (`str`)
+                * stakeThreshold (`str`)
+                * state (`str`)
+                * totalPayout (`str`)
+                * totalStaked (`str`)
+                * tournamentId (`str`)
+        """
+        query = """
+          query($roundId: String!) {
+            v3StakeRound(roundId: $roundId) {
+              closeTime
+              merkleRoot
+              openTime
+              payoutFactor
+              remainingBurn
+              remainingPayout
+              resolveTime
+              resolved
+              roundId
+              stakeCap
+              stakeThreshold
+              state
+              totalPayout
+              totalStaked
+              tournamentId
+            }
+          }
+        """
+        arguments = {"roundId": str(round_id)}
+        return self.raw_query(query, arguments, authorization=True)["data"][
+            "v3StakeRound"
+        ]
+
+    def v3_stake_claim(self, round_id: int | str, model_id: str, staker: str) -> Dict:
+        """Fetch a staking v3 claim proof for a model and staker.
+
+        Args:
+            round_id (int or str): round id
+            model_id (str): model id
+            staker (str): staker wallet address
+
+        Returns:
+            dict: claim payload with the following fields:
+
+                * apiModelId (`str`)
+                * burnAmountWei (`str`)
+                * merkleRoot (`str`)
+                * modelId (`str`)
+                * payoutAmountWei (`str`)
+                * proof (`list` of `str`)
+                * roundId (`str`)
+                * staker (`str`)
+                * submissionId (`str`)
+                * tournamentId (`str`)
+        """
+        query = """
+          query($roundId: String!, $modelId: ID!, $staker: String!) {
+            v3StakeClaim(roundId: $roundId, modelId: $modelId, staker: $staker) {
+              apiModelId
+              burnAmountWei
+              merkleRoot
+              modelId
+              payoutAmountWei
+              proof
+              roundId
+              staker
+              submissionId
+              tournamentId
+            }
+          }
+        """
+        arguments = {
+            "roundId": str(round_id),
+            "modelId": model_id,
+            "staker": staker,
+        }
+        return self.raw_query(query, arguments, authorization=True)["data"][
+            "v3StakeClaim"
+        ]
+
     def get_current_round(self, tournament: int | None = None) -> int | None:
         """Get number of the current active round.
 
@@ -1200,7 +1405,7 @@ class Api:
             return False
         if raw is None:
             return False
-        open_time = utils.parse_datetime_string(raw['openTime'])
+        open_time = utils.parse_datetime_string(raw["openTime"])
         now = datetime.datetime.now(tz=pytz.utc)
         is_new_round = open_time > now - datetime.timedelta(hours=hours)
         return is_new_round

--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -630,8 +630,6 @@ class Api:
         """List rounds with the filters supported by the round resolver.
 
         Args:
-            tournament (int, optional): tournament filter, defaults to the API
-                instance tournament. Pass `None` to omit the tournament filter
             number (int, optional): round number filter
             target (str, optional): round target filter
             status (str, optional): round status filter. One of `upcoming`,

--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -14,7 +14,6 @@ import requests
 from numerapi import utils
 
 API_TOURNAMENT_URL = "https://api-tournament.numer.ai"
-_DEFAULT_TOURNAMENT = object()
 
 
 class Api:
@@ -623,7 +622,6 @@ class Api:
 
     def list_rounds(
         self,
-        tournament: int | None | object = _DEFAULT_TOURNAMENT,
         number: int | None = None,
         target: str | None = None,
         status: str | None = None,
@@ -677,10 +675,8 @@ class Api:
               }
             }
         """
-        if tournament is _DEFAULT_TOURNAMENT:
-            tournament = self.tournament_id if self.tournament_id else None
         arguments = {
-            "tournament": tournament,
+            "tournament": self.tournament_id,
             "number": number,
             "target": target,
             "status": None if status is None else status.upper(),
@@ -1133,7 +1129,6 @@ class Api:
         version: str | None = None,
         day: int | None = None,
         resolved: bool | None = None,
-        tournament: int | None = None,
         last_n_rounds: int | None = None,
         distinct_on_round: bool | None = None,
     ) -> List[Dict]:
@@ -1195,7 +1190,7 @@ class Api:
             "version": version,
             "day": day,
             "resolved": resolved,
-            "tournament": self.tournament_id if tournament is None else tournament,
+            "tournament": self.tournament_id,
             "lastNRounds": last_n_rounds,
             "distinctOnRound": distinct_on_round,
         }

--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import os
+import warnings
 from io import BytesIO
 from typing import Dict, List, Tuple, Union
 
@@ -841,8 +842,144 @@ class Api:
         utils.replace(results, "updatedAt", utils.parse_datetime_string)
         return results
 
+    def submission_scores(
+        self,
+        model_id: str,
+        display_name: str | None = None,
+        version: str | None = None,
+        day: int | None = None,
+        resolved: bool | None = None,
+        tournament: int | None = None,
+        last_n_rounds: int | None = None,
+        distinct_on_round: bool | None = None,
+    ) -> List[Dict]:
+        """Fetch submission score history for a model.
+
+        Args:
+            model_id (str): target model UUID
+            display_name (str, optional): score metric name filter
+            version (str, optional): score version filter
+            day (int, optional): day filter
+            resolved (bool, optional): resolved-state filter
+            tournament (int, optional): tournament filter, defaults to the
+                API instance tournament
+            last_n_rounds (int, optional): limit by most recent rounds
+            distinct_on_round (bool, optional): keep only the latest score per
+                round after applying other filters
+
+        Returns:
+            list of dicts: list of submission score entries
+        """
+
+        query = """
+          query($modelId: ID!
+                $displayName: String
+                $version: String
+                $day: Int
+                $resolved: Boolean
+                $tournament: Int
+                $lastNRounds: Int
+                $distinctOnRound: Boolean) {
+            submissionScores(modelId: $modelId
+                             displayName: $displayName
+                             version: $version
+                             day: $day
+                             resolved: $resolved
+                             tournament: $tournament
+                             lastNRounds: $lastNRounds
+                             distinctOnRound: $distinctOnRound) {
+                roundId
+                submissionId
+                roundNumber
+                roundResolveTime
+                roundScoreTime
+                roundCloseStakingTime
+                value
+                percentile
+                displayName
+                version
+                date
+                day
+                resolveDate
+                resolved
+            }
+          }
+        """
+        arguments = {
+            "modelId": model_id,
+            "displayName": display_name,
+            "version": version,
+            "day": day,
+            "resolved": resolved,
+            "tournament": self.tournament_id if tournament is None else tournament,
+            "lastNRounds": last_n_rounds,
+            "distinctOnRound": distinct_on_round,
+        }
+        scores = self.raw_query(query, arguments)["data"]["submissionScores"]
+        for score in scores:
+            utils.replace(score, "roundResolveTime", utils.parse_datetime_string)
+            utils.replace(score, "roundScoreTime", utils.parse_datetime_string)
+            utils.replace(score, "roundCloseStakingTime", utils.parse_datetime_string)
+            utils.replace(score, "date", utils.parse_datetime_string)
+            utils.replace(score, "resolveDate", utils.parse_datetime_string)
+        return scores
+
+    def pending_model_payouts(self, tournament: int | None = None) -> Dict:
+        """Fetch actual and pending payouts for the authenticated user's models.
+
+        Args:
+            tournament (int, optional): tournament filter, defaults to the API
+                instance tournament
+
+        Returns:
+            dict: payout groups with `actual` and `pending` lists
+        """
+
+        query = """
+          query($tournament: Int!) {
+            pendingModelPayouts(tournament: $tournament) {
+                actual {
+                    roundId
+                    roundNumber
+                    roundResolveTime
+                    modelId
+                    modelName
+                    modelDisplayName
+                    payoutNmr
+                    payoutValue
+                    currencySymbol
+                }
+                pending {
+                    roundId
+                    roundNumber
+                    roundResolveTime
+                    modelId
+                    modelName
+                    modelDisplayName
+                    payoutNmr
+                    payoutValue
+                    currencySymbol
+                }
+            }
+          }
+        """
+        arguments = {
+            "tournament": self.tournament_id if tournament is None else tournament
+        }
+        payouts = self.raw_query(query, arguments, authorization=True)["data"][
+            "pendingModelPayouts"
+        ]
+        for payout_type in ["actual", "pending"]:
+            for payout in payouts[payout_type]:
+                utils.replace(payout, "roundResolveTime", utils.parse_datetime_string)
+                utils.replace(payout, "payoutNmr", utils.parse_float_string)
+                utils.replace(payout, "payoutValue", utils.parse_float_string)
+        return payouts
+
     def round_model_performances_v2(self, model_id: str):
         """Fetch round model performance of a user.
+
+        DEPRECATED - please use `submission_scores` instead when possible.
 
         Args:
             model_id (str)
@@ -871,6 +1008,13 @@ class Api:
                     * percentile (`float`)
                     * value (`float`): value of the metric
         """
+        warnings.warn(
+            "`round_model_performances_v2` is deprecated because it relies on "
+            "`v2RoundModelPerformances`. Use `submission_scores` instead when "
+            "possible.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         query = """
           query($modelId: String!

--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -14,6 +14,7 @@ import requests
 from numerapi import utils
 
 API_TOURNAMENT_URL = "https://api-tournament.numer.ai"
+_DEFAULT_TOURNAMENT = object()
 
 
 class Api:
@@ -619,6 +620,84 @@ class Api:
             return None
         round_num = data["number"]
         return round_num
+
+    def list_rounds(
+        self,
+        tournament: int | None | object = _DEFAULT_TOURNAMENT,
+        number: int | None = None,
+        target: str | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+    ) -> List[Dict]:
+        """List rounds with the filters supported by the round resolver.
+
+        Args:
+            tournament (int, optional): tournament filter, defaults to the API
+                instance tournament. Pass `None` to omit the tournament filter
+            number (int, optional): round number filter
+            target (str, optional): round target filter
+            status (str, optional): round status filter. One of `upcoming`,
+                `open`, `resolving`, or `resolved`
+            limit (int, optional): maximum number of rounds to return
+
+        Returns:
+            list of dicts: round entries matching the provided filters
+        """
+        query = """
+            query($tournament: Int
+                  $number: Int
+                  $target: String
+                  $status: RoundStatus
+                  $limit: Int) {
+              rounds(tournament: $tournament
+                     number: $number
+                     target: $target
+                     status: $status
+                     limit: $limit) {
+                id
+                tournament
+                number
+                target
+                closeTime
+                closeStakingTime
+                openTime
+                scoreTime
+                resolveTime
+                resolvedGeneral
+                resolvedStaking
+                payoutFactor
+                stakeThreshold
+                minCorrMultiplier
+                maxCorrMultiplier
+                defaultCorrMultiplier
+                minMmcMultiplier
+                maxMmcMultiplier
+                defaultMmcMultiplier
+                dataDatestamp
+              }
+            }
+        """
+        if tournament is _DEFAULT_TOURNAMENT:
+            tournament = self.tournament_id if self.tournament_id else None
+        arguments = {
+            "tournament": tournament,
+            "number": number,
+            "target": target,
+            "status": None if status is None else status.upper(),
+            "limit": limit,
+        }
+        rounds = self.raw_query(query, arguments)["data"]["rounds"]
+        for round_info in rounds:
+            for field in [
+                "closeTime",
+                "closeStakingTime",
+                "openTime",
+                "scoreTime",
+                "resolveTime",
+            ]:
+                utils.replace(round_info, field, utils.parse_datetime_string)
+            utils.replace(round_info, "payoutFactor", utils.parse_float_string)
+        return rounds
 
     def set_bio(self, model_id: str, bio: str) -> bool:
         """Set bio field for a model id.

--- a/numerapi/base_api.py
+++ b/numerapi/base_api.py
@@ -427,7 +427,7 @@ class Api:
 
         max_amount = max_amount if max_amount is not None else amount
         query = """
-          mutation($submissionId: ID!, $staker: String!, $maxAmount: String!) {
+          query($submissionId: ID!, $staker: String!, $maxAmount: String!) {
             v3StakeAuth(
               submissionId: $submissionId
               staker: $staker

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def load(path):
     return open(path, "r").read()
 
 
-numerapi_version = "2.23.0.dev1"
+numerapi_version = "2.23.0.dev2"
 
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def load(path):
     return open(path, "r").read()
 
 
-numerapi_version = "2.23.0.dev3"
+numerapi_version = "2.23.0"
 
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def load(path):
     return open(path, "r").read()
 
 
-numerapi_version = "2.23.0.dev2"
+numerapi_version = "2.23.0.dev3"
 
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def load(path):
     return open(path, "r").read()
 
 
-numerapi_version = "2.22.0"
+numerapi_version = "2.23.0.dev0"
 
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def load(path):
     return open(path, "r").read()
 
 
-numerapi_version = "2.23.0.dev0"
+numerapi_version = "2.23.0.dev1"
 
 
 classifiers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,71 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 root_str = str(ROOT)
 if root_str not in sys.path:
     sys.path.insert(0, root_str)
 
+from numerapi import base_api
+
+DEFAULT_FAKE_GRAPHQL_API_URL = "https://fake-api-tournament.numer.ai"
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("graphql")
+    group.addoption(
+        "--mode",
+        action="store",
+        choices=("mock", "integration"),
+        default="mock",
+        help=(
+            "Select whether tests use a fake GraphQL API base URL or a real one. "
+            "Live API tests only run in integration mode."
+        ),
+    )
+    group.addoption(
+        "--api-url",
+        action="store",
+        default=None,
+        help=(
+            "Base GraphQL API URL to use in tests when --mode=integration. "
+            "Defaults to numerapi.base_api.API_TOURNAMENT_URL."
+        ),
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "live_api: test requires a real GraphQL API backend",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--mode") == "integration":
+        return
+
+    skip_live_api = pytest.mark.skip(
+        reason="requires --mode=integration to run against a real GraphQL API backend"
+    )
+    for item in items:
+        if "live_api" in item.keywords:
+            item.add_marker(skip_live_api)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_graphql_api_url(pytestconfig):
+    original_url = base_api.API_TOURNAMENT_URL
+    mode = pytestconfig.getoption("--mode")
+    configured_url = pytestconfig.getoption("--api-url")
+
+    if mode == "integration":
+        base_api.API_TOURNAMENT_URL = configured_url or original_url
+    else:
+        base_api.API_TOURNAMENT_URL = DEFAULT_FAKE_GRAPHQL_API_URL
+
+    yield base_api.API_TOURNAMENT_URL
+
+    base_api.API_TOURNAMENT_URL = original_url

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -297,6 +297,8 @@ def test_v3_stake_auth(api):
     result = api.v3_stake_auth("submission-id", "0xstaker", amount=25)
 
     body = json.loads(responses.calls[0].request.body)
+    assert "mutation" not in body["query"]
+    assert "query(" in body["query"]
     assert "v3StakeAuth" in body["query"]
     assert body["variables"]["submissionId"] == "submission-id"
     assert body["variables"]["maxAmount"] == "25"
@@ -335,6 +337,8 @@ def test_v3_stake_auth_accepts_max_amount(api):
     )
 
     body = json.loads(responses.calls[0].request.body)
+    assert "mutation" not in body["query"]
+    assert "query(" in body["query"]
     assert body["variables"]["maxAmount"] == "30"
     assert result["maxAmount"] == "30"
     assert result["amount"] == "30"

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -1,3 +1,6 @@
+import datetime
+import decimal
+import json
 import os
 import pytest
 import responses
@@ -34,8 +37,14 @@ def test__login(api):
     assert api.token == ("id", "key")
 
 
+@responses.activate
 def test_raw_query(api):
     query = "query {latestNmrPrice {priceUsd}}"
+    responses.add(
+        responses.POST,
+        base_api.API_TOURNAMENT_URL,
+        json={"data": {"latestNmrPrice": {"priceUsd": "42.00"}}},
+    )
     result = api.raw_query(query)
     assert isinstance(result, dict)
     assert "data" in result
@@ -116,3 +125,148 @@ def test_set_submission_webhook(api):
         'https://triggerurl'
     )
     assert res
+
+
+@responses.activate
+def test_submission_scores(api):
+    api.tournament_id = 11
+    data = {
+        "data": {
+            "submissionScores": [
+                {
+                    "roundId": "round-1",
+                    "submissionId": "submission-1",
+                    "roundNumber": 123,
+                    "roundResolveTime": "2026-04-01T00:00:00Z",
+                    "roundScoreTime": "2026-03-29T00:00:00Z",
+                    "roundCloseStakingTime": "2026-03-28T00:00:00Z",
+                    "value": 0.12,
+                    "percentile": 0.95,
+                    "displayName": "CORR20",
+                    "version": "v5",
+                    "date": "2026-03-30T00:00:00Z",
+                    "day": 2,
+                    "resolveDate": "2026-04-01T00:00:00Z",
+                    "resolved": True,
+                }
+            ]
+        }
+    }
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    res = api.submission_scores(
+        "model-1",
+        display_name="CORR20",
+        version="v5",
+        day=2,
+        resolved=True,
+        last_n_rounds=5,
+        distinct_on_round=True,
+    )
+
+    assert len(res) == 1
+    assert res[0]["displayName"] == "CORR20"
+    assert isinstance(res[0]["roundResolveTime"], datetime.datetime)
+    assert isinstance(res[0]["roundScoreTime"], datetime.datetime)
+    assert isinstance(res[0]["roundCloseStakingTime"], datetime.datetime)
+    assert isinstance(res[0]["date"], datetime.datetime)
+    assert isinstance(res[0]["resolveDate"], datetime.datetime)
+
+    request_body = json.loads(responses.calls[0].request.body)
+    assert request_body["variables"]["tournament"] == 11
+    assert request_body["variables"]["lastNRounds"] == 5
+    assert request_body["variables"]["distinctOnRound"] is True
+
+
+@responses.activate
+def test_pending_model_payouts(api):
+    api.token = ("", "")
+    api.tournament_id = 12
+    data = {
+        "data": {
+            "pendingModelPayouts": {
+                "actual": [
+                    {
+                        "roundId": "round-a",
+                        "roundNumber": 12,
+                        "roundResolveTime": "2026-04-02T00:00:00Z",
+                        "modelId": "model-a",
+                        "modelName": "alpha",
+                        "modelDisplayName": "Alpha",
+                        "payoutNmr": "2.5000",
+                        "payoutValue": "31.20",
+                        "currencySymbol": "$",
+                    }
+                ],
+                "pending": [
+                    {
+                        "roundId": "round-b",
+                        "roundNumber": 13,
+                        "roundResolveTime": "2026-04-09T00:00:00Z",
+                        "modelId": "model-b",
+                        "modelName": "beta",
+                        "modelDisplayName": "Beta",
+                        "payoutNmr": "1.1000",
+                        "payoutValue": "13.73",
+                        "currencySymbol": "$",
+                    }
+                ],
+            }
+        }
+    }
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    res = api.pending_model_payouts()
+
+    assert len(res["actual"]) == 1
+    assert len(res["pending"]) == 1
+    assert res["actual"][0]["payoutNmr"] == decimal.Decimal("2.5000")
+    assert res["pending"][0]["payoutValue"] == decimal.Decimal("13.73")
+    assert isinstance(res["actual"][0]["roundResolveTime"], datetime.datetime)
+    assert isinstance(res["pending"][0]["roundResolveTime"], datetime.datetime)
+
+    request_body = json.loads(responses.calls[0].request.body)
+    assert request_body["variables"]["tournament"] == 12
+
+
+@responses.activate
+def test_round_model_performances_v2_warns(api):
+    api.tournament_id = 8
+    data = {
+        "data": {
+            "v2RoundModelPerformances": [
+                {
+                    "atRisk": "10.5",
+                    "corrMultiplier": 1.0,
+                    "mmcMultiplier": 0.5,
+                    "roundPayoutFactor": "0.8",
+                    "roundNumber": 456,
+                    "roundOpenTime": "2026-03-01T00:00:00Z",
+                    "roundResolveTime": "2026-03-29T00:00:00Z",
+                    "roundResolved": True,
+                    "roundTarget": "main",
+                    "submissionScores": [
+                        {
+                            "date": "2026-03-28T00:00:00Z",
+                            "day": 20,
+                            "displayName": "CORR20",
+                            "payoutPending": "0.8",
+                            "payoutSettled": "0.7",
+                            "percentile": 0.9,
+                            "value": 0.12,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    with pytest.warns(DeprecationWarning, match="round_model_performances_v2"):
+        res = api.round_model_performances_v2("model-1")
+
+    assert len(res) == 1
+    assert res[0]["atRisk"] == decimal.Decimal("10.5")
+    assert isinstance(res[0]["roundOpenTime"], datetime.datetime)
+    assert isinstance(res[0]["roundResolveTime"], datetime.datetime)
+    assert res[0]["submissionScores"][0]["payoutPending"] == decimal.Decimal("0.8")

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -179,6 +179,69 @@ def test_submission_scores(api):
 
 
 @responses.activate
+def test_list_rounds(api):
+    api.tournament_id = 11
+    data = {
+        "data": {
+            "rounds": [
+                {
+                    "id": "round-1",
+                    "tournament": 11,
+                    "number": 123,
+                    "target": "main",
+                    "closeTime": "2026-03-27T00:00:00Z",
+                    "closeStakingTime": "2026-03-26T12:00:00Z",
+                    "openTime": "2026-03-20T00:00:00Z",
+                    "scoreTime": "2026-03-29T00:00:00Z",
+                    "resolveTime": "2026-04-01T00:00:00Z",
+                    "resolvedGeneral": False,
+                    "resolvedStaking": False,
+                    "payoutFactor": "0.8",
+                    "stakeThreshold": 0.1,
+                    "minCorrMultiplier": 0.0,
+                    "maxCorrMultiplier": 1.0,
+                    "defaultCorrMultiplier": 0.5,
+                    "minMmcMultiplier": 0.0,
+                    "maxMmcMultiplier": 1.0,
+                    "defaultMmcMultiplier": 0.5,
+                    "dataDatestamp": 20260320,
+                }
+            ]
+        }
+    }
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    res = api.list_rounds(number=123, target="main", status="open", limit=5)
+
+    assert len(res) == 1
+    assert isinstance(res[0]["closeTime"], datetime.datetime)
+    assert isinstance(res[0]["closeStakingTime"], datetime.datetime)
+    assert isinstance(res[0]["openTime"], datetime.datetime)
+    assert isinstance(res[0]["scoreTime"], datetime.datetime)
+    assert isinstance(res[0]["resolveTime"], datetime.datetime)
+    assert isinstance(res[0]["payoutFactor"], decimal.Decimal)
+
+    request_body = json.loads(responses.calls[0].request.body)
+    assert request_body["variables"]["tournament"] == 11
+    assert request_body["variables"]["number"] == 123
+    assert request_body["variables"]["target"] == "main"
+    assert request_body["variables"]["status"] == "OPEN"
+    assert request_body["variables"]["limit"] == 5
+
+
+@responses.activate
+def test_list_rounds_without_tournament_filter(api):
+    api.tournament_id = 11
+    data = {"data": {"rounds": []}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    api.list_rounds(tournament=None)
+
+    request_body = json.loads(responses.calls[0].request.body)
+    assert request_body["variables"]["tournament"] is None
+
+
+@responses.activate
 def test_pending_model_payouts(api):
     api.token = ("", "")
     api.tournament_id = 12

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -230,15 +230,15 @@ def test_list_rounds(api):
 
 
 @responses.activate
-def test_list_rounds_without_tournament_filter(api):
+def test_list_rounds_uses_api_tournament_id_by_default(api):
     api.tournament_id = 11
     data = {"data": {"rounds": []}}
     responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
 
-    api.list_rounds(tournament=None)
+    api.list_rounds()
 
     request_body = json.loads(responses.calls[0].request.body)
-    assert request_body["variables"]["tournament"] is None
+    assert request_body["variables"]["tournament"] == 11
 
 
 @responses.activate

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pytest
 import responses
@@ -116,3 +117,148 @@ def test_set_submission_webhook(api):
         'https://triggerurl'
     )
     assert res
+
+
+@responses.activate
+def test_v3_stake_auth(api):
+    api.token = ("", "")
+    data = {"data": {"v3StakeAuth": {
+        "authorizationSigner": "0xsigner",
+        "authorizationDigest": "0xdigest",
+        "chainId": "11155111",
+        "deadline": "1770000000",
+        "maxAmount": "25",
+        "modelId": "0xmodel",
+        "nmrAddress": "0xnmr",
+        "nonce": "0",
+        "roundId": "4321",
+        "signature": "0x1234",
+        "staker": "0xstaker",
+        "stakingAddress": "0xstaking",
+        "submissionId": "submission-id",
+        "submissionHash": "0xhash",
+        "tournamentId": "8",
+    }}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    result = api.v3_stake_auth("submission-id", "0xstaker", amount=25)
+
+    body = json.loads(responses.calls[0].request.body)
+    assert "v3StakeAuth" in body["query"]
+    assert body["variables"]["submissionId"] == "submission-id"
+    assert body["variables"]["maxAmount"] == "25"
+    assert "maxAmount" in body["query"]
+    assert result["maxAmount"] == "25"
+    assert result["amount"] == "25"
+    assert result["authorizationDigest"] == "0xdigest"
+
+
+@responses.activate
+def test_v3_stake_auth_accepts_max_amount(api):
+    api.token = ("", "")
+    data = {"data": {"v3StakeAuth": {
+        "authorizationSigner": "0xsigner",
+        "authorizationDigest": "0xdigest",
+        "chainId": "11155111",
+        "deadline": "1770000000",
+        "maxAmount": "30",
+        "modelId": "0xmodel",
+        "nmrAddress": "0xnmr",
+        "nonce": "0",
+        "roundId": "4321",
+        "signature": "0x1234",
+        "staker": "0xstaker",
+        "stakingAddress": "0xstaking",
+        "submissionId": "submission-id",
+        "submissionHash": "0xhash",
+        "tournamentId": "8",
+    }}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    result = api.v3_stake_auth(
+        "submission-id",
+        "0xstaker",
+        max_amount="30",
+    )
+
+    body = json.loads(responses.calls[0].request.body)
+    assert body["variables"]["maxAmount"] == "30"
+    assert result["maxAmount"] == "30"
+    assert result["amount"] == "30"
+
+
+@responses.activate
+def test_v3_stake_config(api):
+    api.token = ("", "")
+    data = {"data": {"v3StakeConfig": {
+        "address": "0xstaking",
+        "authorizationSigner": "0xsigner",
+        "nmrAddress": "0xnmr",
+        "owner": "0xowner",
+        "paused": False,
+        "pendingOwner": "0xpending",
+        "serviceWallet": "0xservice",
+    }}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    result = api.v3_stake_config()
+
+    body = json.loads(responses.calls[0].request.body)
+    assert "v3StakeConfig" in body["query"]
+    assert result["authorizationSigner"] == "0xsigner"
+
+
+@responses.activate
+def test_v3_stake_round(api):
+    api.token = ("", "")
+    data = {"data": {"v3StakeRound": {
+        "closeTime": "1",
+        "merkleRoot": "0xroot",
+        "openTime": "0",
+        "payoutFactor": "0.5",
+        "remainingBurn": "0",
+        "remainingPayout": "2",
+        "resolveTime": "2",
+        "resolved": False,
+        "roundId": "4321",
+        "stakeCap": "100",
+        "stakeThreshold": "10",
+        "state": "open",
+        "totalPayout": "2",
+        "totalStaked": "50",
+        "tournamentId": "8",
+    }}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    result = api.v3_stake_round(4321)
+
+    body = json.loads(responses.calls[0].request.body)
+    assert "v3StakeRound" in body["query"]
+    assert body["variables"]["roundId"] == "4321"
+    assert result["roundId"] == "4321"
+
+
+@responses.activate
+def test_v3_stake_claim(api):
+    api.token = ("", "")
+    data = {"data": {"v3StakeClaim": {
+        "apiModelId": "api-model-id",
+        "burnAmountWei": "0",
+        "merkleRoot": "0xroot",
+        "modelId": "0xmodel",
+        "payoutAmountWei": "2000000000000000000",
+        "proof": ["0xproof"],
+        "roundId": "4321",
+        "staker": "0xstaker",
+        "submissionId": "submission-id",
+        "tournamentId": "8",
+    }}}
+    responses.add(responses.POST, base_api.API_TOURNAMENT_URL, json=data)
+
+    result = api.v3_stake_claim(4321, "api-model-id", "0xstaker")
+
+    body = json.loads(responses.calls[0].request.body)
+    assert "v3StakeClaim" in body["query"]
+    assert body["variables"]["roundId"] == "4321"
+    assert body["variables"]["modelId"] == "api-model-id"
+    assert result["proof"] == ["0xproof"]

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -271,6 +271,8 @@ def test_round_model_performances_v2_warns(api):
     assert isinstance(res[0]["roundResolveTime"], datetime.datetime)
     assert res[0]["submissionScores"][0]["payoutPending"] == decimal.Decimal("0.8")
 
+
+@responses.activate
 def test_v3_stake_auth(api):
     api.token = ("", "")
     data = {"data": {"v3StakeAuth": {

--- a/tests/test_cryptoapi.py
+++ b/tests/test_cryptoapi.py
@@ -1,0 +1,13 @@
+import pytest
+
+import numerapi
+
+
+@pytest.fixture(scope='function', name="api")
+def api_fixture():
+    api = numerapi.CryptoAPI(verbosity='DEBUG')
+    return api
+
+def test_get_leaderboard(api):
+    lb = api.get_leaderboard(1)
+    assert len(lb) == 1

--- a/tests/test_cryptoapi.py
+++ b/tests/test_cryptoapi.py
@@ -1,13 +1,43 @@
+import decimal
+from unittest.mock import patch
+
 import pytest
 
 import numerapi
 
 
-@pytest.fixture(scope='function', name="api")
+@pytest.fixture(scope="function", name="api")
 def api_fixture():
-    api = numerapi.CryptoAPI(verbosity='DEBUG')
+    api = numerapi.CryptoAPI(verbosity="DEBUG")
     return api
 
-def test_get_leaderboard(api):
+
+@patch("numerapi.cryptoapi.CryptoAPI.raw_query")
+def test_get_leaderboard(mocked, api):
+    mocked.return_value = {
+        "data": {
+            "cryptosignalsLeaderboard": [
+                {
+                    "nmrStaked": "13.0",
+                    "rank": 1,
+                    "username": "crypto_user",
+                    "corrRep": 0.1,
+                    "mmcRep": 0.2,
+                    "return_1_day": 0.03,
+                    "return_52_weeks": 0.4,
+                    "return_13_weeks": 0.15,
+                }
+            ]
+        }
+    }
+
     lb = api.get_leaderboard(1)
+
     assert len(lb) == 1
+    assert lb[0]["username"] == "crypto_user"
+    assert lb[0]["nmrStaked"] == decimal.Decimal("13.0")
+    mocked.assert_called_once()
+    args, kwargs = mocked.call_args
+    assert "cryptosignalsLeaderboard" in args[0]
+    assert args[1] == {"limit": 1, "offset": 0}
+    assert kwargs == {}

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -15,17 +15,20 @@ def api_fixture():
     return api
 
 
+@pytest.mark.live_api
 def test_get_competitions(api):
     res = api.get_competitions(tournament=1)
     assert isinstance(res, list)
     assert len(res) > 80
 
 
+@pytest.mark.live_api
 def test_get_current_round(api):
     current_round = api.get_current_round()
     assert current_round >= 82
 
 
+@pytest.mark.live_api
 @pytest.mark.parametrize("fun", ["get_account", "wallet_transactions"])
 def test_unauthorized_requests(api, fun):
     with pytest.raises(ValueError) as err:
@@ -37,6 +40,7 @@ def test_unauthorized_requests(api, fun):
            "Your session is invalid or has expired." in str(err.value)
 
 
+@pytest.mark.live_api
 def test_error_handling(api):
     # String instead of Int
     with pytest.raises(ValueError):

--- a/tests/test_numerapi.py
+++ b/tests/test_numerapi.py
@@ -1,5 +1,6 @@
 import pytest
 import datetime
+import json
 import pytz
 import responses
 
@@ -99,3 +100,4 @@ def test_check_new_round(api):
     assert api.check_new_round()
     # second
     assert not api.check_new_round()
+

--- a/tests/test_signalsapi.py
+++ b/tests/test_signalsapi.py
@@ -13,6 +13,7 @@ def api_fixture():
     return api
 
 
+@pytest.mark.live_api
 def test_get_leaderboard(api):
     lb = api.get_leaderboard(1)
     assert len(lb) == 1


### PR DESCRIPTION
- add support for new submission scores API to efficiently query scores for a given model
- add v3 staking APIs including auth creating, claiming, and getting round details
- add round list api function for getting a filtered list of rounds