### PR TITLE
v2.23.1 - Fix version lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 Notable changes to this project.
 
 
+## [2.23.1] - 2026-04-23
+- fix package version lookup
+
+
 ## [2.22.0] - 2026-01-05
 -- added `get_leaderboard` for crypto tournament
 

--- a/numerapi/__init__.py
+++ b/numerapi/__init__.py
@@ -3,9 +3,9 @@
 from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = version("package-name")
+    __version__ = version("numerapi")
 except PackageNotFoundError:
-    __version__ = 'unknown'
+    __version__ = "unknown"
 
 
 # pylint: disable=wrong-import-position

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def load(path):
     return open(path, "r").read()
 
 
-numerapi_version = "2.23.0"
+numerapi_version = "2.23.1"
 
 
 classifiers = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
+import importlib
+import importlib.metadata
 import os
 import pytest
 from click.testing import CliRunner
 from unittest.mock import patch
 
+import numerapi
 from numerapi import cli
 
 
@@ -117,3 +120,19 @@ def test_version():
     result = CliRunner().invoke(cli.version)
     # just testing if calling works fine
     assert result.exit_code == 0
+
+
+def test_version_uses_numerapi_distribution_name(monkeypatch):
+    called_package_names = []
+
+    def mock_version(package_name):
+        called_package_names.append(package_name)
+        return "2.23.1"
+
+    with monkeypatch.context() as context:
+        context.setattr(importlib.metadata, "version", mock_version)
+        importlib.reload(numerapi)
+        assert called_package_names == ["numerapi"]
+        assert numerapi.__version__ == "2.23.1"
+
+    importlib.reload(numerapi)


### PR DESCRIPTION
## Summary
- release the current preview branch toward v2.23.1
- fix numerapi.__version__ to query the installed numerapi distribution instead of the package-name placeholder
- bump package metadata to 2.23.1
- add a regression test for the distribution lookup name

## Scope note
The head branch is preview, so the GitHub compare includes existing preview branch changes that were already on the branch before the version lookup fix. The new commit added for this request is 0de884d (fix version lookup).

## Validation
- /Users/noah/projects/numerapi/.venv/bin/python -m pytest tests/test_cli.py
- /Users/noah/projects/numerapi/.venv/bin/python -c "import numerapi; print(numerapi.__version__)"