### PR TITLE
fix docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     pre_build:
       - sphinx-apidoc --separate --no-toc --force -o docs/api/ numerapi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     'sphinx.ext.doctest',
-    'm2r'
+    'sphinx_mdinclude',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,6 @@
-m2r
+sphinx-mdinclude
+python-dateutil
+tqdm
+pandas
+click
+pytz


### PR DESCRIPTION
With these changes, https://numerapi.readthedocs.io/en/latest/ is up to date again